### PR TITLE
fix(sarasa): apply config skip list to status command

### DIFF
--- a/go/sarasa/cmd/status.go
+++ b/go/sarasa/cmd/status.go
@@ -69,9 +69,12 @@ func runStatus(_ *cobra.Command, _ []string) error {
 		managerNames = manager.List()
 	}
 
+	// Wrap config for skip list access
+	cfgWrapper := &configWrapper{cfg: cfg}
+
 	// JSON output - no TUI
 	if statusJSON {
-		return runStatusJSON(managerNames, opts)
+		return runStatusJSON(managerNames, opts, cfgWrapper)
 	}
 
 	// Detect output mode
@@ -79,23 +82,23 @@ func runStatus(_ *cobra.Command, _ []string) error {
 
 	switch mode {
 	case ui.ModeTUI:
-		return runStatusTUI(managerNames, opts)
+		return runStatusTUI(managerNames, opts, cfgWrapper)
 	case ui.ModeStyled, ui.ModePlain:
-		return runStatusPlain(managerNames, opts, mode == ui.ModeStyled)
+		return runStatusPlain(managerNames, opts, cfgWrapper, mode == ui.ModeStyled)
 	}
 
 	return nil
 }
 
-func runStatusTUI(managerNames []string, opts *manager.Options) error {
-	model := statusTUI.New(managerNames, opts)
+func runStatusTUI(managerNames []string, opts *manager.Options, cfg *configWrapper) error {
+	model := statusTUI.New(managerNames, opts, cfg)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 
 	_, err := p.Run()
 	return err
 }
 
-func runStatusJSON(managerNames []string, opts *manager.Options) error {
+func runStatusJSON(managerNames []string, opts *manager.Options, cfg *configWrapper) error {
 	ctx := context.Background()
 	output := StatusOutput{
 		Managers: make([]ManagerStatus, 0, len(managerNames)),
@@ -117,6 +120,7 @@ func runStatusJSON(managerNames []string, opts *manager.Options) error {
 		}
 
 		if m.IsAvailable() {
+			m.SetSkipList(cfg.GetSkipList(name))
 			outdated, err := m.CheckOutdated(ctx)
 			if err != nil {
 				status.Error = err.Error()
@@ -136,7 +140,7 @@ func runStatusJSON(managerNames []string, opts *manager.Options) error {
 	return nil
 }
 
-func runStatusPlain(managerNames []string, opts *manager.Options, styled bool) error {
+func runStatusPlain(managerNames []string, opts *manager.Options, cfg *configWrapper, styled bool) error {
 	ctx := context.Background()
 
 	// Color helper
@@ -209,6 +213,7 @@ func runStatusPlain(managerNames []string, opts *manager.Options, styled bool) e
 			continue
 		}
 
+		m.SetSkipList(cfg.GetSkipList(name))
 		outdated, err := m.CheckOutdated(ctx)
 		if err != nil {
 			fmt.Printf("    %s %s\n\n", c(red, ui.IconCross), c(red, err.Error()))

--- a/go/sarasa/internal/config/config_test.go
+++ b/go/sarasa/internal/config/config_test.go
@@ -209,6 +209,51 @@ skip_major = true
 	}
 }
 
+func TestLoadFrom_VoltaSkipList(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.toml")
+
+	configContent := `
+[skip]
+volta = ["agent-browser", "@google/gemini-cli"]
+`
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	cfg, err := config.LoadFrom(configPath)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	skipList := cfg.GetSkipList("volta")
+	if len(skipList) != 2 {
+		t.Fatalf("expected 2 volta skip items, got %d", len(skipList))
+	}
+	if skipList[0] != "agent-browser" {
+		t.Errorf("expected first skip item to be agent-browser, got %s", skipList[0])
+	}
+	if skipList[1] != "@google/gemini-cli" {
+		t.Errorf("expected second skip item to be @google/gemini-cli, got %s", skipList[1])
+	}
+
+	// Verify ShouldSkip works end-to-end from loaded config
+	if !cfg.ShouldSkip("volta", "agent-browser") {
+		t.Error("expected agent-browser to be skipped for volta")
+	}
+	if !cfg.ShouldSkip("volta", "@google/gemini-cli") {
+		t.Error("expected @google/gemini-cli to be skipped for volta")
+	}
+	if cfg.ShouldSkip("volta", "wrangler") {
+		t.Error("expected wrangler to not be skipped for volta")
+	}
+	// Skip list is per-manager
+	if cfg.ShouldSkip("npm", "agent-browser") {
+		t.Error("expected agent-browser to not be skipped for npm")
+	}
+}
+
 func TestSaveAndLoad(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "sarasa", "config.toml")

--- a/go/sarasa/internal/manager/skiplist_test.go
+++ b/go/sarasa/internal/manager/skiplist_test.go
@@ -1,0 +1,182 @@
+package manager
+
+import (
+	"testing"
+)
+
+func TestVolta_SetSkipList(t *testing.T) {
+	opts := &Options{}
+	v := NewVolta(opts)
+
+	v.SetSkipList([]string{"agent-browser", "@google/gemini-cli"})
+
+	if !opts.ShouldSkip("agent-browser") {
+		t.Error("expected agent-browser to be skipped after SetSkipList")
+	}
+	if !opts.ShouldSkip("@google/gemini-cli") {
+		t.Error("expected @google/gemini-cli to be skipped after SetSkipList")
+	}
+	if opts.ShouldSkip("wrangler") {
+		t.Error("expected wrangler to not be skipped")
+	}
+}
+
+func TestNPM_SetSkipList(t *testing.T) {
+	opts := &Options{}
+	n := NewNPM(opts)
+
+	n.SetSkipList([]string{"typescript", "eslint"})
+
+	if !opts.ShouldSkip("typescript") {
+		t.Error("expected typescript to be skipped after SetSkipList")
+	}
+	if !opts.ShouldSkip("eslint") {
+		t.Error("expected eslint to be skipped after SetSkipList")
+	}
+	if opts.ShouldSkip("prettier") {
+		t.Error("expected prettier to not be skipped")
+	}
+}
+
+func TestBun_SetSkipList(t *testing.T) {
+	opts := &Options{}
+	b := NewBun(opts)
+
+	b.SetSkipList([]string{"bun-pkg"})
+
+	if !opts.ShouldSkip("bun-pkg") {
+		t.Error("expected bun-pkg to be skipped after SetSkipList")
+	}
+	if opts.ShouldSkip("other") {
+		t.Error("expected other to not be skipped")
+	}
+}
+
+func TestSetSkipList_OverwritesPrevious(t *testing.T) {
+	opts := &Options{SkipList: []string{"old-pkg"}}
+	v := NewVolta(opts)
+
+	if !opts.ShouldSkip("old-pkg") {
+		t.Error("expected old-pkg to be skipped initially")
+	}
+
+	v.SetSkipList([]string{"new-pkg"})
+
+	if opts.ShouldSkip("old-pkg") {
+		t.Error("expected old-pkg to no longer be skipped after SetSkipList override")
+	}
+	if !opts.ShouldSkip("new-pkg") {
+		t.Error("expected new-pkg to be skipped after SetSkipList override")
+	}
+}
+
+func TestSetSkipList_EmptyClears(t *testing.T) {
+	opts := &Options{SkipList: []string{"pkg1"}}
+	v := NewVolta(opts)
+
+	v.SetSkipList([]string{})
+
+	if opts.ShouldSkip("pkg1") {
+		t.Error("expected pkg1 to no longer be skipped after setting empty list")
+	}
+}
+
+func TestSetSkipList_NilClears(t *testing.T) {
+	opts := &Options{SkipList: []string{"pkg1"}}
+	v := NewVolta(opts)
+
+	v.SetSkipList(nil)
+
+	if opts.ShouldSkip("pkg1") {
+		t.Error("expected pkg1 to no longer be skipped after setting nil list")
+	}
+}
+
+// TestVoltaCheckOutdated_SkipFiltering verifies that the skip list filters
+// packages during the parsing phase of CheckOutdated. Since CheckOutdated
+// calls external commands, we test the filtering logic directly using
+// parseVoltaList + ShouldSkip, which is the exact code path.
+func TestVoltaCheckOutdated_SkipFiltering(t *testing.T) {
+	input := `runtime node@24.13.0 (default)
+package-manager npm@11.8.0 (default)
+package agent-browser@0.8.5 / agent-browser / node@24.13.0 npm@built-in (default)
+package wrangler@4.59.1 / wrangler, wrangler2 / node@24.13.0 npm@built-in (default)
+package @google/gemini-cli@0.25.0 / gemini / node@24.13.0 npm@built-in (default)
+package pilotty@0.0.6 / pilotty / node@24.13.0 npm@built-in (default)`
+
+	installed, _ := parseVoltaList(input)
+
+	opts := &Options{
+		SkipList: []string{"agent-browser", "@google/gemini-cli"},
+	}
+
+	var filtered []voltaPackage
+	for _, pkg := range installed {
+		if opts.ShouldSkip(pkg.name) {
+			continue
+		}
+		filtered = append(filtered, pkg)
+	}
+
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 packages after filtering, got %d", len(filtered))
+	}
+	if filtered[0].name != "wrangler" {
+		t.Errorf("expected first package to be wrangler, got %s", filtered[0].name)
+	}
+	if filtered[1].name != "pilotty" {
+		t.Errorf("expected second package to be pilotty, got %s", filtered[1].name)
+	}
+}
+
+// TestVoltaCheckOutdated_SkipAll verifies that skipping all packages yields
+// an empty result.
+func TestVoltaCheckOutdated_SkipAll(t *testing.T) {
+	input := `runtime node@24.13.0 (default)
+package agent-browser@0.8.5 / agent-browser / node@24.13.0 npm@built-in (default)
+package wrangler@4.59.1 / wrangler / node@24.13.0 npm@built-in (default)`
+
+	installed, _ := parseVoltaList(input)
+
+	opts := &Options{
+		SkipList: []string{"agent-browser", "wrangler"},
+	}
+
+	var filtered []voltaPackage
+	for _, pkg := range installed {
+		if opts.ShouldSkip(pkg.name) {
+			continue
+		}
+		filtered = append(filtered, pkg)
+	}
+
+	if len(filtered) != 0 {
+		t.Errorf("expected 0 packages after skipping all, got %d", len(filtered))
+	}
+}
+
+// TestVoltaCheckOutdated_EmptySkipFiltersNothing verifies that an empty skip
+// list does not filter any packages.
+func TestVoltaCheckOutdated_EmptySkipFiltersNothing(t *testing.T) {
+	input := `runtime node@24.13.0 (default)
+package agent-browser@0.8.5 / agent-browser / node@24.13.0 npm@built-in (default)
+package wrangler@4.59.1 / wrangler / node@24.13.0 npm@built-in (default)`
+
+	installed, _ := parseVoltaList(input)
+
+	opts := &Options{
+		SkipList: []string{},
+	}
+
+	var filtered []voltaPackage
+	for _, pkg := range installed {
+		if opts.ShouldSkip(pkg.name) {
+			continue
+		}
+		filtered = append(filtered, pkg)
+	}
+
+	if len(filtered) != 2 {
+		t.Errorf("expected 2 packages with empty skip list, got %d", len(filtered))
+	}
+}

--- a/go/sarasa/internal/tui/status/model.go
+++ b/go/sarasa/internal/tui/status/model.go
@@ -22,10 +22,16 @@ type ManagerStatus struct {
 	Loading   bool
 }
 
+// ManagerConfigProvider provides per-manager config.
+type ManagerConfigProvider interface {
+	GetSkipList(manager string) []string
+}
+
 // Model is the bubbletea model for the status command.
 type Model struct {
 	managers  []string
 	opts      *manager.Options
+	cfg       ManagerConfigProvider
 	statuses  map[string]*ManagerStatus
 	loadOrder []string
 	spinner   spinner.Model
@@ -39,7 +45,7 @@ type Model struct {
 type allLoadedMsg struct{}
 
 // New creates a new status TUI model.
-func New(managerNames []string, opts *manager.Options) Model {
+func New(managerNames []string, opts *manager.Options, cfg ManagerConfigProvider) Model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = ui.StyleSpinner
@@ -55,6 +61,7 @@ func New(managerNames []string, opts *manager.Options) Model {
 	return Model{
 		managers:  managerNames,
 		opts:      opts,
+		cfg:       cfg,
 		statuses:  statuses,
 		loadOrder: managerNames,
 		spinner:   s,
@@ -85,6 +92,9 @@ func (m Model) loadAllManagers() tea.Cmd {
 			} else {
 				status.Available = mgr.IsAvailable()
 				if status.Available {
+					if m.cfg != nil {
+						mgr.SetSkipList(m.cfg.GetSkipList(name))
+					}
 					outdated, err := mgr.CheckOutdated(ctx)
 					if err != nil {
 						status.Error = err


### PR DESCRIPTION
## Summary

- The `status` command was not applying the config's `[skip]` section to managers, so skipped packages still appeared in output. The `run` command already did this correctly.
- Wires `SetSkipList` from config in all three status code paths: plain, JSON, and TUI.
- Adds `ManagerConfigProvider` interface to the status TUI model (matching the existing pattern in the run TUI).

## Context

Discovered while debugging a broken `agent-browser` symlink under Volta ([vercel-labs/agent-browser#324](https://github.com/vercel-labs/agent-browser/issues/324)). Adding `agent-browser` to the volta skip list in `~/.config/sarasa/config.toml` had no effect on `sarasa status` because the skip list was never passed through.

## Test plan

- [x] New tests in `internal/manager/skiplist_test.go` covering `SetSkipList` for all managers, override/clear semantics, and parse+filter integration
- [x] New config test `TestLoadFrom_VoltaSkipList` verifying end-to-end TOML load → `GetSkipList` → `ShouldSkip`
- [x] All existing tests pass (`go test ./...`)
- [x] Manual verification: `sarasa status --managers volta` no longer shows `agent-browser` when it is in the volta skip list