### PR TITLE
feat(sarasa): change default schedule to every 2 hours

### DIFF
--- a/go/sarasa/internal/config/config.go
+++ b/go/sarasa/internal/config/config.go
@@ -67,7 +67,11 @@ func DefaultConfig() *Config {
 			Bun:   []string{},
 		},
 		Schedule: ScheduleConfig{
-			Times: []string{"08:00", "14:00", "22:00"},
+			Times: []string{
+				"00:00", "02:00", "04:00", "06:00",
+				"08:00", "10:00", "12:00", "14:00",
+				"16:00", "18:00", "20:00", "22:00",
+			},
 		},
 		Logging: LoggingConfig{
 			Dir:           filepath.Join(homeDir, "Library", "Logs", "sarasa"),

--- a/go/sarasa/internal/config/config_test.go
+++ b/go/sarasa/internal/config/config_test.go
@@ -22,8 +22,12 @@ func TestDefaultConfig(t *testing.T) {
 		}
 	}
 
-	// Check default schedule times
-	expectedTimes := []string{"08:00", "14:00", "22:00"}
+	// Check default schedule times (every 2 hours)
+	expectedTimes := []string{
+		"00:00", "02:00", "04:00", "06:00",
+		"08:00", "10:00", "12:00", "14:00",
+		"16:00", "18:00", "20:00", "22:00",
+	}
 	if len(cfg.Schedule.Times) != len(expectedTimes) {
 		t.Errorf("expected %d schedule times, got %d", len(expectedTimes), len(cfg.Schedule.Times))
 	}

--- a/go/sarasa/internal/scheduler/launchd.go
+++ b/go/sarasa/internal/scheduler/launchd.go
@@ -132,8 +132,17 @@ func DefaultConfig() (*Config, error) {
 		BinaryPath: binaryPath,
 		LogDir:     filepath.Join(homeDir, "Library", "Logs", "sarasa"),
 		Times: []ScheduleTime{
+			{Hour: 0, Minute: 0},
+			{Hour: 2, Minute: 0},
+			{Hour: 4, Minute: 0},
+			{Hour: 6, Minute: 0},
 			{Hour: 8, Minute: 0},
+			{Hour: 10, Minute: 0},
+			{Hour: 12, Minute: 0},
 			{Hour: 14, Minute: 0},
+			{Hour: 16, Minute: 0},
+			{Hour: 18, Minute: 0},
+			{Hour: 20, Minute: 0},
 			{Hour: 22, Minute: 0},
 		},
 	}, nil


### PR DESCRIPTION
## Summary
- Change default launchd schedule from 3x/day (8:00, 14:00, 22:00) to every 2 hours

## Test plan
- [x] `go test ./...` passes
- [x] `sarasa schedule install` verified on local machine
- [x] `launchctl list com.sarasa.upgrade` confirms agent loaded