### PR TITLE
fix(yantraganana): prevent JSON corruption from hanging commands

### DIFF
--- a/shell/dev-setup/yantraganana.sh
+++ b/shell/dev-setup/yantraganana.sh
@@ -110,7 +110,7 @@ _timeout_run() {
         while (<$fh>) { print }
         close $fh;
         alarm(0);
-    ' -- "$@" 2>/dev/null || true
+    ' -- "$@" || true
 }
 
 # Read a file as a JSON string (max 50KB), or null if missing
@@ -874,12 +874,18 @@ collect_vscode() {
 collect_fonts() {
     _phase "Developer Fonts"
 
-    local fonts_json
-    fonts_json=$(find "$HOME/Library/Fonts" /Library/Fonts -maxdepth 1 \
-        \( -name "*.ttf" -o -name "*.otf" -o -name "*.ttc" \) -exec basename {} \; 2>/dev/null \
-        | sort -u \
-        | sgrep -iE 'nerd|mono|code|fira|jetbrains|hack|iosevka|cascadia|source.?code|inconsolata|menlo|sf.?mono' \
-        | jq -R '.' | jq -s '.')
+    local font_dirs=()
+    [[ -d "$HOME/Library/Fonts" ]] && font_dirs+=("$HOME/Library/Fonts")
+    [[ -d "/Library/Fonts" ]] && font_dirs+=("/Library/Fonts")
+
+    local fonts_json="[]"
+    if [[ ${#font_dirs[@]} -gt 0 ]]; then
+        fonts_json=$(find "${font_dirs[@]}" -maxdepth 1 \
+            \( -name "*.ttf" -o -name "*.otf" -o -name "*.ttc" \) -exec basename {} \; 2>/dev/null \
+            | sort -u \
+            | sgrep -iE 'nerd|mono|code|fira|jetbrains|hack|iosevka|cascadia|source.?code|inconsolata|menlo|sf.?mono' \
+            | jq -R '.' | jq -s '.')
+    fi
     [[ -z "$fonts_json" || "$fonts_json" == "null" ]] && fonts_json="[]"
     local font_count
     font_count=$(echo "$fonts_json" | jq 'length')


### PR DESCRIPTION
## Summary
- **Root cause**: `xcodebuild -version` hangs indefinitely on some macOS configs, truncating the JSON output mid-stream
- **Fix**: Added perl-based `_timeout_run` (10s) for all version-detection commands; replaced all manual JSON construction with `jq -n` fragment-per-collector + `jq -s 'add'` merge — making JSON corruption structurally impossible
- **Bonus**: Fixed cask versions showing `.metadata` instead of real versions; added structured log file at `~/.local/state/yantraganana/`

## What changed
| Before | After |
|--------|-------|
| Manual `json_escape()` + heredocs | `jq --arg` handles all escaping |
| One hung collector truncates entire output | Per-collector JSON fragments merged at end |
| No timeout on version commands | 10s perl `alarm()` timeout (no GNU coreutils needed) |
| Cask versions show `.metadata` | Real versions from Caskroom dirs |
| No debug trail | Timestamped log file with PHASE/OK/WARN/ERROR levels |

## Test plan
- [x] Full script run completes in ~10s, produces valid JSON with all 24 sections
- [x] shellcheck clean (zero warnings)
- [x] iTerm2 driver automation: 12/12 tests pass (timeout guard, box alignment, JSON validation, log structure, cask versions, runtimes section)
- [x] Lefthook pre-push CI: shell lint, python lint, go lint, go tests all pass