### PR TITLE
fix(saamagri): fail Phase 5 when jq missing, fix Python fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
           cache-dependency-path: go/sarasa/go.sum
 
       - name: Install shellcheck
-        run: sudo apt-get install -y shellcheck
+        run: |
+          SC_VERSION=0.11.0
+          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/v${SC_VERSION}/shellcheck-v${SC_VERSION}.linux.x86_64.tar.xz" \
+            | tar -xJf - --strip-components=1 -C /usr/local/bin "shellcheck-v${SC_VERSION}/shellcheck"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/shell/dev-setup/saamagri.sh
+++ b/shell/dev-setup/saamagri.sh
@@ -114,8 +114,10 @@ _bootstrap_path() {
         eval "$(/usr/local/bin/brew shellenv 2>/dev/null)" || true
     fi
     # Cargo/Rust
-    # shellcheck source=/dev/null
-    [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env" 2>/dev/null || true
+    if [ -f "$HOME/.cargo/env" ]; then
+        # shellcheck source=/dev/null
+        . "$HOME/.cargo/env" 2>/dev/null || true
+    fi
     # Volta
     if [ -d "$HOME/.volta" ]; then
         export VOLTA_HOME="$HOME/.volta"


### PR DESCRIPTION
## Summary
Fixes bugs in saamagri.sh found through code review, Codex bot feedback, and a दूतसभा council review (Codex + Gemini).

## Changes

### Critical
- **PATH rehydration on resume**: `--phase N` from a fresh shell couldn't find brew/cargo/volta/bun. Added `_bootstrap_path()` that probes all tool locations at startup
- **Phase 5 false-success**: Marked complete even when formula/cask installs failed, poisoning Phases 6-17. Now tracks failures and returns 1

### High
- **Python fallback correctness**: `inv_get`/`inv_content` output Python reprs instead of JSON, swallowed falsey values (`0`, `False`), and crashed on bare `[]` tokens. Rewrote with `json.dumps()`, explicit `None` checks, and proper tokenizer
- **Phase 10 CI hang**: Blocking `read` in `--yes` mode. Now skips SSH key prompt in non-interactive mode
- **Phase 5 criticality**: Extended critical phase boundary from 1-4 to 1-5 (Codex bot catch)

### Improvements
- **Structured logging**: All output functions now write to the WAL log via `_wal` with ANSI stripping
- **Duplicate phase prevention**: `mark_phase_complete` checks before appending
- **CI shellcheck pinned to 0.11.0**: Replaced `apt-get install shellcheck` (0.9.0) with GitHub releases binary to match local version and avoid SC2015 false positives

## Test plan
- [x] `--dry-run --yes` completes cleanly with full structured log output
- [x] Python fallback correctly resolves array indices and falsey values
- [x] shellcheck clean (0.11.0)
- [x] CI green (shellcheck 0.11.0, ruff, golangci-lint, go test)
- [x] Codex bot review comments addressed and resolved
- [x] दूतसभा council findings incorporated (Gemini validated all Codex findings as "100% correct")