### PR TITLE
fix(sarasa): add skills to default managers and detect stale configs on install

### DIFF
--- a/.claude/automations/test_sarasa_install_config_hint.py
+++ b/.claude/automations/test_sarasa_install_config_hint.py
@@ -1,0 +1,620 @@
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#   "iterm2",
+#   "pyobjc",
+#   "pyobjc-framework-Quartz",
+# ]
+# ///
+"""
+Visual test: install.sh config-upgrade detection and sarasa config suggest.
+
+Tests the new installer behavior when upgrading sarasa with a stale config
+that's missing newly available managers (e.g., skills).
+
+Tests:
+    1. config suggest --json with stale config: should report missing managers
+    2. config suggest --json with current config: should report no missing
+    3. config suggest styled (TTY) with stale config: shows hint text
+    4. install.sh post-install hint box: simulated upgrade with stale config
+    5. install.sh post-install no hint: simulated upgrade with current config
+
+Verification Strategy:
+    - Build sarasa from local source
+    - Create temp config files to simulate stale/current configs
+    - Run commands in iTerm2 to capture styled output
+    - Verify screen text and capture screenshots
+
+Screenshots:
+    - config_hint_01_suggest_json_stale.png
+    - config_hint_02_suggest_styled.png
+    - config_hint_03_install_stale_config.png
+    - config_hint_04_install_current_config.png
+
+Screenshot Inspection Checklist:
+    - Hint box: correct box drawing, colors, alignment
+    - Manager names: displayed with correct icons/colors
+    - "sarasa init --force" prompt visible
+    - No hint shown when config is already current
+
+Key Bindings:
+    - n: decline reconfigure prompt
+    - Ctrl+C: interrupt
+
+Usage:
+    uv run .claude/automations/test_sarasa_install_config_hint.py
+"""
+
+import asyncio
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+
+import iterm2
+
+try:
+    import Quartz
+except ImportError:
+    Quartz = None
+
+# ============================================================
+# CONFIGURATION
+# ============================================================
+
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+SARASA_DIR = PROJECT_ROOT / "go" / "sarasa"
+SCREENSHOT_DIR = PROJECT_ROOT / ".claude" / "automations" / "screenshots"
+TIMEOUT_SECONDS = 8.0
+
+# ============================================================
+# RESULT TRACKING
+# ============================================================
+
+results = {
+    "passed": 0,
+    "failed": 0,
+    "tests": [],
+    "screenshots": [],
+    "start_time": None,
+}
+
+
+def log_result(test_name, status, details="", screenshot=None):
+    results["tests"].append({"name": test_name, "status": status, "details": details})
+    if screenshot:
+        results["screenshots"].append(screenshot)
+    symbol = "+" if status == "PASS" else "x"
+    results["passed" if status == "PASS" else "failed"] += 1
+    print(f"  [{symbol}] {status}: {test_name}")
+    if details:
+        print(f"      {details}")
+    if screenshot:
+        print(f"      Screenshot: {screenshot}")
+
+
+def print_summary():
+    total = results["passed"] + results["failed"]
+    duration = (
+        (datetime.now() - results["start_time"]).total_seconds()
+        if results["start_time"]
+        else 0
+    )
+    print(f"\n{'=' * 60}")
+    print("TEST SUMMARY")
+    print(f"{'=' * 60}")
+    print(f"Duration:    {duration:.1f}s")
+    print(f"Total:       {total}")
+    print(f"Passed:      {results['passed']}")
+    print(f"Failed:      {results['failed']}")
+    if results["screenshots"]:
+        print(f"Screenshots: {len(results['screenshots'])}")
+    print("=" * 60)
+    if results["failed"] > 0:
+        print("\nFailed tests:")
+        for t in results["tests"]:
+            if t["status"] == "FAIL":
+                print(f"  - {t['name']}: {t['details']}")
+        print("\nOVERALL: FAILED")
+        return 1
+    print("\nOVERALL: PASSED")
+    return 0
+
+
+# ============================================================
+# QUARTZ SCREENSHOT
+# ============================================================
+
+
+def find_quartz_window_id(target_x, target_w, target_h, tolerance=30):
+    if not Quartz:
+        return None
+    window_list = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly
+        | Quartz.kCGWindowListExcludeDesktopElements,
+        Quartz.kCGNullWindowID,
+    )
+    best_id, best_score = None, float("inf")
+    for w in window_list:
+        if "iTerm" not in w.get("kCGWindowOwnerName", ""):
+            continue
+        b = w.get("kCGWindowBounds", {})
+        score = (
+            abs(float(b.get("X", 0)) - target_x) * 2
+            + abs(float(b.get("Width", 0)) - target_w)
+            + abs(float(b.get("Height", 0)) - target_h)
+        )
+        if score < best_score:
+            best_score, best_id = score, w.get("kCGWindowNumber")
+    return best_id if best_score < tolerance else None
+
+
+async def capture_screenshot(window, name):
+    SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    filepath = SCREENSHOT_DIR / f"config_hint_{name}_{timestamp}.png"
+
+    frame = await window.async_get_frame()
+    qid = find_quartz_window_id(frame.origin.x, frame.size.width, frame.size.height)
+
+    if qid:
+        subprocess.run(
+            ["screencapture", "-x", "-l", str(qid), str(filepath)], check=True
+        )
+    else:
+        subprocess.run(["screencapture", "-x", str(filepath)], check=True)
+
+    print(f"  SCREENSHOT: {filepath.name}")
+    return str(filepath)
+
+
+# ============================================================
+# WINDOW CREATION
+# ============================================================
+
+
+async def create_test_window(
+    connection, name="test", x_pos=50, width=1200, height=900
+):
+    window = await iterm2.Window.async_create(connection)
+    if window is None:
+        raise RuntimeError("Window.async_create() returned None")
+
+    await asyncio.sleep(0.5)
+
+    app = await iterm2.async_get_app(connection)
+    if window.current_tab is None:
+        for w in app.terminal_windows:
+            if w.window_id == window.window_id:
+                window = w
+                break
+
+    for _ in range(20):
+        if window.current_tab and window.current_tab.current_session:
+            break
+        await asyncio.sleep(0.2)
+
+    if not window.current_tab or not window.current_tab.current_session:
+        raise RuntimeError("Window tab/session not ready after timeout")
+
+    session = window.current_tab.current_session
+    await session.async_set_name(name)
+
+    # Position window prominently for clear screenshots
+    await window.async_set_frame(
+        iterm2.Frame(
+            iterm2.Point(x_pos, 50),
+            iterm2.Size(width, height),
+        )
+    )
+    await asyncio.sleep(0.5)
+
+    # Set a larger font for screenshot readability
+    profile = await session.async_get_profile()
+    await profile.async_set_normal_font("MesloLGS-NF-Regular 16")
+    await asyncio.sleep(0.3)
+
+    return window, session
+
+
+# ============================================================
+# VERIFICATION HELPERS
+# ============================================================
+
+
+async def get_all_screen_text(session):
+    screen = await session.async_get_screen_contents()
+    lines = []
+    for i in range(screen.number_of_lines):
+        lines.append(screen.line(i).string)
+    return lines
+
+
+async def wait_for_text(session, target, timeout=None):
+    timeout = timeout or TIMEOUT_SECONDS
+    start = time.monotonic()
+    while (time.monotonic() - start) < timeout:
+        lines = await get_all_screen_text(session)
+        for line in lines:
+            if target in line:
+                return True
+        await asyncio.sleep(0.3)
+    return False
+
+
+async def screen_contains(session, target):
+    lines = await get_all_screen_text(session)
+    return any(target in line for line in lines)
+
+
+async def dump_screen(session, label):
+    lines = await get_all_screen_text(session)
+    print(f"\n{'=' * 60}")
+    print(f"SCREEN DUMP: {label}")
+    print(f"{'=' * 60}")
+    for i, line in enumerate(lines):
+        if line.strip():
+            print(f"{i:03d}: {line}")
+    print(f"{'=' * 60}\n")
+
+
+async def cleanup_session(session):
+    try:
+        await session.async_send_text("\x03")
+        await asyncio.sleep(0.1)
+        await session.async_send_text("exit\n")
+        await asyncio.sleep(0.2)
+        await session.async_close()
+    except Exception:
+        pass
+
+
+# ============================================================
+# TEST CONFIGS
+# ============================================================
+
+STALE_CONFIG = """\
+managers = ["brew", "volta", "pipx", "bun"]
+
+[skip]
+brew = []
+
+[schedule]
+times = ["08:00", "14:00", "22:00"]
+
+[logging]
+retention_days = 30
+level = "info"
+"""
+
+CURRENT_CONFIG = """\
+managers = ["brew", "volta", "pipx", "bun", "skills"]
+
+[skip]
+brew = []
+
+[schedule]
+times = ["08:00", "14:00", "22:00"]
+
+[logging]
+retention_days = 30
+level = "info"
+"""
+
+# Install.sh fragment that sources only the display/check functions
+# and calls check_config_updates with a custom config path.
+INSTALL_SH_HARNESS = """\
+#!/bin/bash
+set -uo pipefail
+
+export HOME="{fake_home}"
+
+# Source install.sh to get function definitions.
+# The main guard prevents main() from running.
+source "{install_sh}"
+
+# Override variables that install.sh set during source
+INSTALL_PREFIX="{install_prefix}"
+RUN_INIT="false"
+
+# Call just the config check function
+check_config_updates || echo "(no config updates)"
+"""
+
+
+# ============================================================
+# MAIN
+# ============================================================
+
+
+async def main(connection):
+    results["start_time"] = datetime.now()
+
+    print("\n" + "#" * 60)
+    print("# TEST: install.sh config-upgrade detection")
+    print("#" * 60)
+
+    # Build sarasa
+    print("\nBuilding sarasa from local source...")
+    sarasa_bin = str(SARASA_DIR / "sarasa-test-binary")
+    build = subprocess.run(
+        ["go", "build", "-o", sarasa_bin, "."],
+        cwd=str(SARASA_DIR),
+        capture_output=True,
+        text=True,
+    )
+    if build.returncode != 0:
+        print(f"BUILD FAILED:\n{build.stderr}")
+        log_result("Build", "FAIL", build.stderr)
+        return print_summary()
+    print("  Build OK")
+
+    window, session = await create_test_window(
+        connection, "config-hint-test", x_pos=150
+    )
+    created_sessions = [session]
+
+    try:
+        # ============================================================
+        # TEST 1: config suggest --json with stale config
+        # ============================================================
+        print(f"\n{'=' * 60}")
+        print("TEST 1: config suggest --json (stale config)")
+        print(f"{'=' * 60}")
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".toml", delete=False
+        ) as f:
+            f.write(STALE_CONFIG)
+            stale_path = f.name
+
+        out = subprocess.run(
+            [sarasa_bin, "--config", stale_path, "config", "suggest", "--json"],
+            capture_output=True,
+            text=True,
+        )
+        os.unlink(stale_path)
+
+        if '"skills"' in out.stdout and '"missing"' in out.stdout:
+            log_result(
+                "config suggest --json (stale)",
+                "PASS",
+                f"Output: {out.stdout.strip()[:120]}",
+            )
+        else:
+            log_result(
+                "config suggest --json (stale)",
+                "FAIL",
+                f"Expected 'skills' in missing. Got: {out.stdout.strip()[:200]}",
+            )
+
+        # ============================================================
+        # TEST 2: config suggest --json with current config
+        # ============================================================
+        print(f"\n{'=' * 60}")
+        print("TEST 2: config suggest --json (current config)")
+        print(f"{'=' * 60}")
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".toml", delete=False
+        ) as f:
+            f.write(CURRENT_CONFIG)
+            current_path = f.name
+
+        out = subprocess.run(
+            [sarasa_bin, "--config", current_path, "config", "suggest", "--json"],
+            capture_output=True,
+            text=True,
+        )
+        os.unlink(current_path)
+
+        if '"missing": null' in out.stdout or '"missing": []' in out.stdout:
+            log_result(
+                "config suggest --json (current)",
+                "PASS",
+                "No missing managers reported",
+            )
+        else:
+            log_result(
+                "config suggest --json (current)",
+                "FAIL",
+                f"Expected no missing. Got: {out.stdout.strip()[:200]}",
+            )
+
+        # ============================================================
+        # TEST 3: config suggest styled output (stale config, in TTY)
+        # ============================================================
+        print(f"\n{'=' * 60}")
+        print("TEST 3: config suggest styled (stale config, TTY)")
+        print(f"{'=' * 60}")
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".toml", delete=False
+        ) as f:
+            f.write(STALE_CONFIG)
+            stale_path = f.name
+
+        await session.async_send_text(
+            f"clear && {sarasa_bin} --config {stale_path} config suggest\n"
+        )
+        await asyncio.sleep(2)
+
+        found_new = await screen_contains(session, "New managers available")
+        found_skills = await screen_contains(session, "skills")
+        found_init = await screen_contains(session, "sarasa init --force")
+        screenshot = await capture_screenshot(window, "02_suggest_styled")
+
+        # Clean up temp file
+        await session.async_send_text(f"rm -f {stale_path}\n")
+        await asyncio.sleep(0.3)
+
+        if found_new and found_skills and found_init:
+            log_result(
+                "config suggest styled (TTY)",
+                "PASS",
+                "Hint text, skills name, and init command all visible",
+                screenshot=screenshot,
+            )
+        else:
+            await dump_screen(session, "suggest styled output")
+            details = (
+                f"new_managers={found_new}, skills={found_skills}, init={found_init}"
+            )
+            log_result(
+                "config suggest styled (TTY)",
+                "FAIL",
+                details,
+                screenshot=screenshot,
+            )
+
+        # ============================================================
+        # TEST 4: install.sh post-install hint (stale config)
+        # ============================================================
+        print(f"\n{'=' * 60}")
+        print("TEST 4: install.sh hint box (stale config)")
+        print(f"{'=' * 60}")
+
+        # Create a fake HOME with stale config
+        fake_home = tempfile.mkdtemp(prefix="sarasa-test-home-")
+        fake_config_dir = os.path.join(fake_home, ".config", "sarasa")
+        os.makedirs(fake_config_dir)
+        with open(os.path.join(fake_config_dir, "config.toml"), "w") as f:
+            f.write(STALE_CONFIG)
+
+        # Create the skills lock file so IsAvailable() returns true
+        fake_agents_dir = os.path.join(fake_home, ".agents")
+        os.makedirs(fake_agents_dir)
+        with open(os.path.join(fake_agents_dir, ".skill-lock.json"), "w") as f:
+            f.write("{}")
+
+        # Also create a fake install prefix with the binary
+        fake_prefix = os.path.join(fake_home, ".local", "bin")
+        os.makedirs(fake_prefix)
+        subprocess.run(["cp", sarasa_bin, os.path.join(fake_prefix, "sarasa")])
+
+        # Write the harness script
+        harness_path = os.path.join(fake_home, "test_install.sh")
+        harness_content = INSTALL_SH_HARNESS.format(
+            install_prefix=fake_prefix,
+            fake_home=fake_home,
+            install_sh=str(SARASA_DIR / "install.sh"),
+        )
+        with open(harness_path, "w") as f:
+            f.write(harness_content)
+        os.chmod(harness_path, 0o755)
+
+        await session.async_send_text(f"clear && bash {harness_path}\n")
+        await asyncio.sleep(3)
+
+        found_hint = await screen_contains(session, "New managers available")
+        found_skills = await screen_contains(session, "skills")
+        found_box_top = await screen_contains(session, "╭")
+        found_box_bot = await screen_contains(session, "╰")
+        screenshot = await capture_screenshot(window, "03_install_stale_config")
+
+        # Cleanup
+        await session.async_send_text(f"rm -rf {fake_home}\n")
+        await asyncio.sleep(0.3)
+
+        if found_hint and found_skills and found_box_top and found_box_bot:
+            log_result(
+                "install.sh hint box (stale config)",
+                "PASS",
+                "Hint box with skills suggestion displayed",
+                screenshot=screenshot,
+            )
+        else:
+            await dump_screen(session, "install hint output")
+            details = f"hint={found_hint}, skills={found_skills}, box_top={found_box_top}, box_bot={found_box_bot}"
+            log_result(
+                "install.sh hint box (stale config)",
+                "FAIL",
+                details,
+                screenshot=screenshot,
+            )
+
+        # ============================================================
+        # TEST 5: install.sh no hint (current config)
+        # ============================================================
+        print(f"\n{'=' * 60}")
+        print("TEST 5: install.sh no hint (current config)")
+        print(f"{'=' * 60}")
+
+        # Create a fake HOME with current config
+        fake_home2 = tempfile.mkdtemp(prefix="sarasa-test-home2-")
+        fake_config_dir2 = os.path.join(fake_home2, ".config", "sarasa")
+        os.makedirs(fake_config_dir2)
+        with open(os.path.join(fake_config_dir2, "config.toml"), "w") as f:
+            f.write(CURRENT_CONFIG)
+
+        fake_prefix2 = os.path.join(fake_home2, ".local", "bin")
+        os.makedirs(fake_prefix2)
+        subprocess.run(["cp", sarasa_bin, os.path.join(fake_prefix2, "sarasa")])
+
+        harness_path2 = os.path.join(fake_home2, "test_install.sh")
+        harness_content2 = INSTALL_SH_HARNESS.format(
+            install_prefix=fake_prefix2,
+            fake_home=fake_home2,
+            install_sh=str(SARASA_DIR / "install.sh"),
+        )
+        with open(harness_path2, "w") as f:
+            f.write(harness_content2)
+        os.chmod(harness_path2, 0o755)
+
+        await session.async_send_text(f"clear && bash {harness_path2}\n")
+        await asyncio.sleep(3)
+
+        # Should NOT show the hint
+        no_hint = not await screen_contains(session, "New managers available")
+        has_no_updates = await screen_contains(session, "(no config updates)")
+        screenshot = await capture_screenshot(window, "04_install_current_config")
+
+        await session.async_send_text(f"rm -rf {fake_home2}\n")
+        await asyncio.sleep(0.3)
+
+        if no_hint and has_no_updates:
+            log_result(
+                "install.sh no hint (current config)",
+                "PASS",
+                "No hint shown — config is current",
+                screenshot=screenshot,
+            )
+        else:
+            await dump_screen(session, "install no-hint output")
+            log_result(
+                "install.sh no hint (current config)",
+                "FAIL",
+                f"no_hint={no_hint}, no_updates={has_no_updates}",
+                screenshot=screenshot,
+            )
+
+    except Exception as e:
+        print(f"\nERROR: {e}")
+        import traceback
+
+        traceback.print_exc()
+        log_result("Test Execution", "FAIL", str(e))
+        try:
+            await dump_screen(session, "error_state")
+        except Exception:
+            pass
+
+    finally:
+        # Clean up built binary
+        try:
+            os.unlink(sarasa_bin)
+        except Exception:
+            pass
+
+        for s in created_sessions:
+            await cleanup_session(s)
+
+    return print_summary()
+
+
+if __name__ == "__main__":
+    exit_code = iterm2.run_until_complete(main)
+    sys.exit(exit_code or 0)

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ uv run python/games/space-war.py
 
 [`sarasa`](go/sarasa/) is a CLI tool for automated global package manager upgrades with scheduled background execution via launchd.
 
-**Supported managers:** 🍺 brew · ⚡ volta · 📦 npm · 🐍 pipx · 🥟 bun (uses volta when detected, otherwise npm)
+**Supported managers:** 🍺 brew · ⚡ volta · 📦 npm · 🐍 pipx · 🥟 bun · 🔧 skills (uses volta when detected, otherwise npm)
 
 | Command | Description |
 |---------|-------------|
@@ -203,7 +203,7 @@ sarasa logs
 **Configuration:** `~/.config/sarasa/config.toml`
 
 ```toml
-managers = ["brew", "volta", "npm", "pipx", "bun"]
+managers = ["brew", "volta", "npm", "pipx", "bun", "skills"]
 
 [skip]
 brew = ["postgresql@14"]  # Packages to skip

--- a/go/sarasa/cmd/config.go
+++ b/go/sarasa/cmd/config.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/indrasvat/sarasa/internal/manager"
+	"github.com/indrasvat/sarasa/internal/ui"
+)
+
+var configCmd = &cobra.Command{
+	Use:    "config",
+	Short:  "Configuration utilities",
+	Hidden: true, // Internal; used by install.sh
+}
+
+// SuggestOutput is the JSON output for config suggest.
+type SuggestOutput struct {
+	ConfigPath string   `json:"config_path"`
+	Configured []string `json:"configured"`
+	Missing    []string `json:"missing"`
+}
+
+var suggestJSON bool
+
+var suggestCmd = &cobra.Command{
+	Use:   "suggest",
+	Short: "Suggest managers available but not in config",
+	Long: `Check for package managers that are available on this system
+but not listed in the current config's managers list.
+
+Used by install.sh to detect stale configs after upgrades.`,
+	RunE: runSuggest,
+}
+
+func init() {
+	rootCmd.AddCommand(configCmd)
+	configCmd.AddCommand(suggestCmd)
+	suggestCmd.Flags().BoolVar(&suggestJSON, "json", false, "output as JSON")
+}
+
+func runSuggest(_ *cobra.Command, _ []string) error {
+	cfg := GetConfig()
+	opts := &manager.Options{}
+
+	// Build set of currently configured managers
+	configured := make(map[string]bool)
+	for _, m := range cfg.Managers {
+		configured[m] = true
+	}
+
+	// Check all registered managers for availability
+	var missing []string
+	for _, name := range manager.List() {
+		if configured[name] {
+			continue
+		}
+		m, err := manager.Get(name, opts)
+		if err != nil {
+			continue
+		}
+		if m.IsAvailable() {
+			missing = append(missing, name)
+		}
+	}
+
+	if suggestJSON {
+		out := SuggestOutput{
+			ConfigPath: configPath(),
+			Configured: cfg.Managers,
+			Missing:    missing,
+		}
+		data, err := json.MarshalIndent(out, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	// Styled output for terminal
+	if ui.IsTTY() {
+		fmt.Printf("\n  %s New managers available but not in your config:\n", ui.IconSparkle)
+		for _, name := range missing {
+			fmt.Printf("    %s %s %s\n", ui.ManagerIcon(name), name, "(available)")
+		}
+		fmt.Printf("\n  Run %ssarasa init --force%s to add them.\n\n",
+			"\033[1m\033[96m", "\033[0m")
+	} else {
+		fmt.Println(strings.Join(missing, "\n"))
+	}
+
+	return nil
+}

--- a/go/sarasa/cmd/config.go
+++ b/go/sarasa/cmd/config.go
@@ -46,6 +46,22 @@ func runSuggest(_ *cobra.Command, _ []string) error {
 	cfg := GetConfig()
 	opts := &manager.Options{}
 
+	// An empty managers list means "all managers enabled" — nothing to suggest.
+	if len(cfg.Managers) == 0 {
+		if suggestJSON {
+			out := SuggestOutput{
+				ConfigPath: configPath(),
+				Configured: cfg.Managers,
+			}
+			data, err := json.MarshalIndent(out, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(data))
+		}
+		return nil
+	}
+
 	// Build set of currently configured managers
 	configured := make(map[string]bool)
 	for _, m := range cfg.Managers {

--- a/go/sarasa/cmd/root.go
+++ b/go/sarasa/cmd/root.go
@@ -23,7 +23,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "sarasa",
 	Short: "Automated global package manager upgrades",
-	Long: `Sarasa automates global package upgrades for brew, volta/npm, bun, and pipx
+	Long: `Sarasa automates global package upgrades for brew, volta/npm, bun, pipx, and skills
 with scheduled background execution via launchd.
 
 Uses volta when detected, otherwise falls back to npm.

--- a/go/sarasa/install.sh
+++ b/go/sarasa/install.sh
@@ -131,7 +131,7 @@ show_banner() {
     _box_line "${BOLD}SARASA INSTALLER${RST}"
     _box_line ""
     _box_line "Automated global package upgrades for macOS"
-    _box_line "${DIM}brew  ·  volta  ·  npm  ·  pipx  ·  bun${RST}"
+    _box_line "${DIM}brew  ·  volta  ·  npm  ·  pipx  ·  bun  ·  skills${RST}"
     _box_line ""
     _box_rule "╰" "╯"
     printf "\n"
@@ -311,21 +311,119 @@ install_binary() {
     _done "Installed to ${BOLD}${INSTALL_PREFIX}/sarasa${RST}"
 }
 
+# ── Config check ───────────────────────────────────────────────
+# Detect available managers not in the user's existing config.
+# Uses `sarasa config suggest --json` for accurate availability checks.
+check_config_updates() {
+    local sarasa_bin="${INSTALL_PREFIX}/sarasa"
+    local config_path
+    config_path="${HOME}/.config/sarasa/config.toml"
+
+    # Only relevant if a config already exists (upgrade scenario)
+    if [ ! -f "$config_path" ]; then
+        return 1
+    fi
+
+    # Run suggest and capture JSON
+    local suggest_json
+    suggest_json="$("$sarasa_bin" config suggest --json 2>/dev/null)" || return 1
+
+    # Extract missing managers (lightweight JSON parse — no jq dependency).
+    # Collapse JSON to one line, then extract array body between "missing": [ ... ]
+    local missing=""
+    local collapsed
+    collapsed="$(printf '%s' "$suggest_json" | tr -d '\n')"
+
+    # Bail early if "missing": null or no array
+    if printf '%s' "$collapsed" | grep -q '"missing":[[:space:]]*\['; then
+        local arr_body
+        arr_body="$(printf '%s' "$collapsed" \
+            | sed -E 's/.*"missing":[[:space:]]*\[//;s/\].*//')"
+        missing="$(printf '%s' "$arr_body" \
+            | grep -o '"[a-zA-Z_-]*"' \
+            | tr -d '"' \
+            | tr '\n' ' ')"
+        missing="${missing% }"  # trim trailing space
+    fi
+
+    if [ -z "$missing" ]; then
+        return 1
+    fi
+
+    # Show hint box
+    printf "\n"
+    _box_rule "╭" "╮"
+    _box_line ""
+    _box_line "${BYEL}!${RST}  ${BOLD}New managers available${RST}"
+    _box_line ""
+    _box_line "Your config is missing managers that are"
+    _box_line "now available on this system:"
+    _box_line ""
+    for mgr in $missing; do
+        _box_line "  ${BCYN}+${RST}  ${BOLD}${mgr}${RST}"
+    done
+    _box_line ""
+    # Shorten config path for display (replace $HOME with ~)
+    local display_path="${config_path/#$HOME/\~}"
+    _box_line "Run ${BOLD}sarasa init --force${RST} to add them,"
+    _box_line "or edit ${DIM}${display_path}${RST}"
+    _box_line ""
+    _box_rule "╰" "╯"
+
+    # Offer interactive reconfigure
+    if [ -t 0 ] && [ -t 1 ] && [ "$RUN_INIT" = "true" ]; then
+        printf "\n"
+        printf "  %sReconfigure now?%s [Y/n] " "$BOLD" "$RST"
+        local reply
+        read -r reply
+        case "$reply" in
+            [Nn]*)
+                printf "  %s Keeping existing config.\n" "$DIM"
+                return 0
+                ;;
+            *)
+                printf "\n"
+                "$sarasa_bin" init --force
+                return 0
+                ;;
+        esac
+    fi
+
+    return 0
+}
+
 # ── Post-install ────────────────────────────────────────────────
 post_install() {
+    local is_upgrade="false"
+    if [ -f "${HOME}/.config/sarasa/config.toml" ]; then
+        is_upgrade="true"
+    fi
+
     printf "\n"
     _box_rule "╭" "╮"
     _box_line ""
     _box_line "${BGRN}OK${RST} ${BOLD}Installation complete!${RST}"
     _box_line ""
 
-    if [ "$RUN_INIT" = "true" ] && [ -t 0 ] && [ -t 1 ]; then
+    if [ "$is_upgrade" = "true" ]; then
+        # Upgrade path: check for stale config
+        _box_line "Next steps:"
+        _box_line "  ${BOLD}sarasa status${RST}   -- check outdated packages"
+        _box_line "  ${BOLD}sarasa run${RST}      -- upgrade everything"
+        _box_line ""
+        _box_rule "╰" "╯"
+
+        # Show config hint if new managers are available
+        check_config_updates || true
+    elif [ "$RUN_INIT" = "true" ] && [ -t 0 ] && [ -t 1 ]; then
+        # Fresh install, interactive: run init wizard
         _box_line "Running ${BOLD}sarasa init${RST} to configure..."
         _box_line ""
         _box_rule "╰" "╯"
         printf "\n"
         "${INSTALL_PREFIX}/sarasa" init
     else
+        # Fresh install, non-interactive: show next steps
         _box_line "Next steps:"
         _box_line "  ${BOLD}sarasa init${RST}     -- interactive setup"
         _box_line "  ${BOLD}sarasa status${RST}   -- check outdated packages"
@@ -357,4 +455,8 @@ main() {
     post_install
 }
 
-main
+# Guard: only run main when executed directly, not when sourced.
+# This allows test harnesses to source the functions independently.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi

--- a/go/sarasa/install.sh
+++ b/go/sarasa/install.sh
@@ -457,6 +457,8 @@ main() {
 
 # Guard: only run main when executed directly, not when sourced.
 # This allows test harnesses to source the functions independently.
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# When piped via stdin (curl | bash), BASH_SOURCE[0] is empty and $0 is
+# the shell name, so we also check for that case.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]}" ]]; then
     main
 fi

--- a/go/sarasa/internal/config/config.go
+++ b/go/sarasa/internal/config/config.go
@@ -59,7 +59,7 @@ type VoltaConfig struct {
 func DefaultConfig() *Config {
 	homeDir, _ := os.UserHomeDir()
 	return &Config{
-		Managers: []string{"brew", "volta", "pipx", "bun"},
+		Managers: []string{"brew", "volta", "pipx", "bun", "skills"},
 		Skip: SkipConfig{
 			Brew:   []string{},
 			NPM:    []string{},

--- a/go/sarasa/internal/config/config_test.go
+++ b/go/sarasa/internal/config/config_test.go
@@ -12,7 +12,7 @@ func TestDefaultConfig(t *testing.T) {
 	cfg := config.DefaultConfig()
 
 	// Check default managers
-	expectedManagers := []string{"brew", "volta", "pipx", "bun"}
+	expectedManagers := []string{"brew", "volta", "pipx", "bun", "skills"}
 	if len(cfg.Managers) != len(expectedManagers) {
 		t.Errorf("expected %d managers, got %d", len(expectedManagers), len(cfg.Managers))
 	}
@@ -56,7 +56,7 @@ func TestIsManagerEnabled(t *testing.T) {
 	cfg := config.DefaultConfig()
 
 	// Check enabled managers
-	for _, m := range []string{"brew", "volta", "pipx", "bun"} {
+	for _, m := range []string{"brew", "volta", "pipx", "bun", "skills"} {
 		if !cfg.IsManagerEnabled(m) {
 			t.Errorf("expected %s to be enabled", m)
 		}
@@ -65,9 +65,6 @@ func TestIsManagerEnabled(t *testing.T) {
 	// Check disabled managers
 	if cfg.IsManagerEnabled("npm") {
 		t.Error("expected npm to be disabled in default config")
-	}
-	if cfg.IsManagerEnabled("skills") {
-		t.Error("expected skills to be disabled in default config")
 	}
 
 	// Check unknown manager


### PR DESCRIPTION
## Summary

- Add `skills` to `DefaultConfig().Managers` so fresh installs include it without requiring `sarasa init`
- Add config-upgrade detection to `install.sh`: when upgrading with an existing config that's missing newly available managers, show a styled hint box suggesting `sarasa init --force`
- Add hidden `sarasa config suggest` command for fast local-only availability checks (used by install.sh)
- Update CLI help, install banner, and README to include skills

## Test plan

- [x] `go test ./...` — all pass
- [x] `shellcheck install.sh` — clean
- [x] iTerm2 visual tests (`test_sarasa_install_config_hint.py`) — 5/5 pass
  - Stale config → hint box with missing manager names
  - Current config → no hint shown
  - `config suggest --json` → correct JSON output
  - `config suggest` styled → correct TTY rendering