### PR TITLE
chore: add agent tooling ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ ENV/
 .claude/screenshots/
 .claude/automations/screenshots/
 
+# Agent tooling outputs
+.codemap/
+.githuman/
+
 # Logs
 *.log
 /logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+`CLAUDE.md` is the source of truth for repository guidance.
+
+Agents should read and follow [CLAUDE.md](./CLAUDE.md).


### PR DESCRIPTION
## Summary
- ignore generated .codemap and .githuman directories
- add AGENTS.md that delegates repository guidance to CLAUDE.md

## Verification
- pre-push make ci