### PR TITLE
feat(sarasa): handle missing custom tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,13 +221,17 @@ default_timeout = "10m"
 [[custom.tools]]
 name = "nidhi"
 binary = "nidhi"
+missing = "install"  # bootstrap if absent; default is "skip"
 current = { argv = ["nidhi", "--version"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
 latest = { github_release = "indrasvat/nidhi" }
 upgrade = { shell = "curl -sSfL https://raw.githubusercontent.com/indrasvat/nidhi/main/install.sh | bash -s -- --version ${latest} --dir ~/.local/bin" }
 verify = { argv = ["nidhi", "--version"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
 ```
 
-See [`go/sarasa/README.md`](go/sarasa/README.md) for custom recipe patterns, self-updater examples, and verification notes.
+`latest.github_release` uses `GITHUB_TOKEN`/`GH_TOKEN` when set and falls back
+to authenticated `gh api` after GitHub 401/403 responses. See
+[`go/sarasa/README.md`](go/sarasa/README.md) for custom recipe patterns,
+self-updater examples, and verification notes.
 
 ## Guides
 

--- a/go/sarasa/README.md
+++ b/go/sarasa/README.md
@@ -72,6 +72,7 @@ default_timeout = "10m"
 [[custom.tools]]
 name = "nidhi"
 binary = "nidhi"
+missing = "install"
 current = { argv = ["nidhi", "--version"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
 latest = { github_release = "indrasvat/nidhi" }
 upgrade = { shell = "curl -sSfL https://raw.githubusercontent.com/indrasvat/nidhi/main/install.sh | bash -s -- --version ${latest} --dir ~/.local/bin" }
@@ -106,6 +107,31 @@ upgrade = { argv = ["claude", "upgrade"] }
 verify = { argv = ["claude", "--version"], regex = "[0-9]+\\.[0-9]+\\.[0-9]+" }
 ```
 
+### Missing Tool Policy
+
+By default, a custom recipe with `binary = "tool"` is skipped when the binary is
+not present in `PATH`. Use `missing = "install"` for installer recipes that
+should bootstrap the tool when it is absent:
+
+```toml
+[[custom.tools]]
+name = "shux"
+binary = "shux"
+missing = "install"
+current = { argv = ["shux", "--version"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
+latest = { github_release = "indrasvat/shux" }
+upgrade = { shell = "curl -sSfL https://raw.githubusercontent.com/indrasvat/shux/main/install.sh | sh -s -- --version ${latest} --dir ~/.local/bin", timeout = "15m" }
+verify = { argv = ["shux", "--version"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
+```
+
+Supported values:
+
+| Policy | Behavior |
+| --- | --- |
+| unset / `skip` | Skip the recipe when `binary` is absent |
+| `install` | Report `not installed → latest` and run `upgrade` |
+| `fail` | Fail the custom manager when `binary` is absent |
+
 ### Local Repo Installer
 
 Use this for tools you build and install from an active checkout.
@@ -126,6 +152,7 @@ verify = { argv = ["local-tool", "--version"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9
 | --- | --- |
 | `name` | Display name and skip-list key |
 | `binary` | Optional executable used to decide whether the tool is installed |
+| `missing` | Missing-binary policy: `skip`, `install`, or `fail` |
 | `current` | Command probe for the installed version |
 | `latest` | Latest version provider |
 | `outdated` | Optional policy override |
@@ -162,6 +189,11 @@ Latest providers:
 | `github_release` | `latest = { github_release = "owner/repo" }` |
 | command probe | `latest = { argv = ["tool", "latest"], regex = "..." }` |
 | self-managed | `latest = { mode = "self" }` |
+
+For `github_release`, sarasa calls the GitHub Releases API. It uses
+`GITHUB_TOKEN` or `GH_TOKEN` when either is set, and falls back to authenticated
+`gh api` on GitHub 401/403 responses when the GitHub CLI is available. This
+keeps public release checks working after unauthenticated API rate limits.
 
 Outdated modes:
 

--- a/go/sarasa/cmd/run.go
+++ b/go/sarasa/cmd/run.go
@@ -236,6 +236,7 @@ func runRunPlain(managers []manager.Manager, opts *manager.Options, cfg runTUI.M
 				"error", err.Error(),
 			)
 			fmt.Printf("    %s %s\n\n", c(red, ui.IconCross), c(red, err.Error()))
+			totalFailed++
 			continue
 		}
 
@@ -325,9 +326,13 @@ func runRunPlain(managers []manager.Manager, opts *manager.Options, cfg runTUI.M
 	var summaryParts []string
 
 	if runDryRun {
+		if totalFailed > 0 {
+			summaryParts = append(summaryParts, c(red, fmt.Sprintf("%d failed", totalFailed)))
+		}
 		if totalSkipped > 0 {
 			summaryParts = append(summaryParts, c(brightMagenta, fmt.Sprintf("%d to upgrade", totalSkipped)))
-		} else {
+		}
+		if totalFailed == 0 && totalSkipped == 0 {
 			summaryParts = append(summaryParts, c(green, "All up to date"))
 		}
 	} else {

--- a/go/sarasa/internal/config/config.go
+++ b/go/sarasa/internal/config/config.go
@@ -69,6 +69,7 @@ type CustomToolConfig struct {
 	Name           string               `toml:"name"`
 	Binary         string               `toml:"binary"`
 	Description    string               `toml:"description"`
+	Missing        string               `toml:"missing"`
 	Current        CustomProbeConfig    `toml:"current"`
 	Latest         CustomLatestConfig   `toml:"latest"`
 	Outdated       CustomOutdatedConfig `toml:"outdated"`

--- a/go/sarasa/internal/config/config_test.go
+++ b/go/sarasa/internal/config/config_test.go
@@ -148,6 +148,7 @@ default_timeout = "30s"
 [[custom.tools]]
 name = "demo"
 binary = "demo"
+missing = "install"
 timeout = "1m"
 allow_unchanged = true
 current = { argv = ["demo", "--version"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
@@ -172,6 +173,9 @@ verify = { argv = ["demo", "--version"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
 	tool := cfg.Custom.Tools[0]
 	if tool.Name != "demo" {
 		t.Errorf("tool.Name = %q, want demo", tool.Name)
+	}
+	if tool.Missing != "install" {
+		t.Errorf("tool.Missing = %q, want install", tool.Missing)
 	}
 	if !tool.AllowUnchanged {
 		t.Error("expected allow_unchanged=true")

--- a/go/sarasa/internal/manager/custom.go
+++ b/go/sarasa/internal/manager/custom.go
@@ -30,9 +30,18 @@ type Custom struct {
 }
 
 const (
-	customMethodCommand = "command"
-	customLatestSelf    = "self"
-	customUnknown       = "unknown"
+	customMethodCommand  = "command"
+	customLatestSelf     = "self"
+	customMissingSkip    = "skip"
+	customMissingInstall = "install"
+	customMissingFail    = "fail"
+	customNotInstalled   = "not installed"
+	customUnknown        = "unknown"
+)
+
+var (
+	githubAPIBaseURL = "https://api.github.com"
+	githubHTTPClient = &http.Client{Timeout: 15 * time.Second}
 )
 
 // NewCustom creates a custom-tool manager.
@@ -69,7 +78,16 @@ func (c *Custom) CheckOutdated(ctx context.Context) ([]Package, error) {
 			continue
 		}
 		if !customToolAvailable(tool) {
-			log.Warn("Skipping unavailable custom tool", "tool", tool.Name, "binary", tool.Binary)
+			pkg, outdated, err := c.checkMissingTool(ctx, tool)
+			if err != nil {
+				return nil, err
+			}
+			if outdated {
+				packages = append(packages, pkg)
+			}
+			if !outdated {
+				log.Warn("Skipping unavailable custom tool", "tool", tool.Name, "binary", tool.Binary)
+			}
 			continue
 		}
 
@@ -228,6 +246,42 @@ func (c *Custom) checkTool(ctx context.Context, tool config.CustomToolConfig) (P
 	}, outdated, nil
 }
 
+func (c *Custom) checkMissingTool(ctx context.Context, tool config.CustomToolConfig) (Package, bool, error) {
+	switch missingPolicy(tool) {
+	case customMissingSkip:
+		return Package{}, false, nil
+	case customMissingFail:
+		return Package{}, false, fmt.Errorf("custom tool %q missing binary %q", tool.Name, tool.Binary)
+	case customMissingInstall:
+		latest, latestMethod, err := latestVersion(ctx, c.opts.Config.Custom.DefaultTimeout, tool)
+		if err != nil {
+			return Package{}, false, err
+		}
+		return Package{
+			Name:    tool.Name,
+			Current: customNotInstalled,
+			Latest:  displayVersion(latest),
+			IsMajor: false,
+			Method:  methodTag(latestMethod, actionMethod(tool.Upgrade)),
+		}, true, nil
+	default:
+		return Package{}, false, fmt.Errorf("unknown missing policy %q for custom tool %q", tool.Missing, tool.Name)
+	}
+}
+
+func missingPolicy(tool config.CustomToolConfig) string {
+	switch strings.TrimSpace(strings.ToLower(tool.Missing)) {
+	case "", customMissingSkip:
+		return customMissingSkip
+	case customMissingInstall:
+		return customMissingInstall
+	case customMissingFail:
+		return customMissingFail
+	default:
+		return strings.TrimSpace(strings.ToLower(tool.Missing))
+	}
+}
+
 func customToolAvailable(tool config.CustomToolConfig) bool {
 	if tool.Binary == "" {
 		return true
@@ -308,18 +362,18 @@ func isCustomOutdated(ctx context.Context, defaultTimeout string, tool config.Cu
 }
 
 func latestGitHubRelease(ctx context.Context, repo string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.github.com/repos/"+repo+"/releases/latest", nil)
+	url := strings.TrimRight(githubAPIBaseURL, "/") + "/repos/" + repo + "/releases/latest"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "sarasa")
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+	if token := githubToken(); token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 
-	client := &http.Client{Timeout: 15 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := githubHTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -328,7 +382,15 @@ func latestGitHubRelease(ctx context.Context, repo string) (string, error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("github releases latest returned HTTP %d for %s", resp.StatusCode, repo)
+		statusErr := fmt.Errorf("github releases latest returned HTTP %d for %s", resp.StatusCode, repo)
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			if version, ghErr := latestGitHubReleaseWithGH(ctx, repo); ghErr == nil {
+				return version, nil
+			} else {
+				return "", fmt.Errorf("%w; gh api fallback failed: %w", statusErr, ghErr)
+			}
+		}
+		return "", statusErr
 	}
 
 	var payload struct {
@@ -341,6 +403,33 @@ func latestGitHubRelease(ctx context.Context, repo string) (string, error) {
 		return "", fmt.Errorf("github release for %s did not include tag_name", repo)
 	}
 	return payload.TagName, nil
+}
+
+func githubToken() string {
+	for _, name := range []string{"GITHUB_TOKEN", "GH_TOKEN"} {
+		if token := strings.TrimSpace(os.Getenv(name)); token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
+func latestGitHubReleaseWithGH(ctx context.Context, repo string) (string, error) {
+	if _, err := osexec.LookPath("gh"); err != nil {
+		return "", err
+	}
+	cmd := osexec.CommandContext(ctx, "gh", "api", "repos/"+repo+"/releases/latest", "--jq", ".tag_name")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	tag := strings.TrimSpace(stdout.String())
+	if tag == "" {
+		return "", fmt.Errorf("github release for %s did not include tag_name", repo)
+	}
+	return tag, nil
 }
 
 func runVersionProbe(ctx context.Context, defaultTimeout, toolTimeout string, probe config.CustomProbeConfig, vars map[string]string) (string, error) {

--- a/go/sarasa/internal/manager/custom_test.go
+++ b/go/sarasa/internal/manager/custom_test.go
@@ -2,8 +2,11 @@ package manager
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/indrasvat/sarasa/internal/config"
@@ -125,6 +128,211 @@ func TestCustomUpgradeDryRunDoesNotRunAction(t *testing.T) {
 	}
 	if string(data) != "1.0.0" {
 		t.Errorf("dry-run changed version file to %q", data)
+	}
+}
+
+func TestCustomMissingPolicySkipByDefault(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Custom.Tools = []config.CustomToolConfig{
+		{
+			Name:    "missing-skip",
+			Binary:  "__sarasa_missing_binary__",
+			Latest:  config.CustomLatestConfig{Value: "1.0.0"},
+			Upgrade: config.CustomActionConfig{Shell: "printf should-not-run"},
+		},
+	}
+
+	got, err := NewCustom(&Options{Config: cfg}).CheckOutdated(context.Background())
+	if err != nil {
+		t.Fatalf("CheckOutdated failed: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected missing skip policy to report no packages, got %d", len(got))
+	}
+}
+
+func TestCustomMissingPolicyInstallDryRun(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Custom.Tools = []config.CustomToolConfig{
+		{
+			Name:    "missing-install",
+			Binary:  "__sarasa_missing_binary__",
+			Missing: "install",
+			Latest:  config.CustomLatestConfig{Value: "1.2.3"},
+			Upgrade: config.CustomActionConfig{Shell: "printf should-not-run"},
+		},
+	}
+
+	result, err := NewCustom(&Options{Config: cfg}).Upgrade(context.Background(), true)
+	if err != nil {
+		t.Fatalf("Upgrade dry-run failed: %v", err)
+	}
+	if len(result.Skipped) != 1 {
+		t.Fatalf("expected 1 skipped package, got %d", len(result.Skipped))
+	}
+	pkg := result.Skipped[0]
+	if pkg.Name != "missing-install" {
+		t.Errorf("Name = %q, want missing-install", pkg.Name)
+	}
+	if pkg.Current != customNotInstalled {
+		t.Errorf("Current = %q, want %q", pkg.Current, customNotInstalled)
+	}
+	if pkg.Latest != "1.2.3" {
+		t.Errorf("Latest = %q, want 1.2.3", pkg.Latest)
+	}
+	if pkg.Method != "pinned / shell" {
+		t.Errorf("Method = %q, want pinned / shell", pkg.Method)
+	}
+}
+
+func TestCustomMissingPolicyInstallRunsAndVerifies(t *testing.T) {
+	tmpDir := t.TempDir()
+	versionFile := filepath.Join(tmpDir, "installed-version.txt")
+
+	cfg := config.DefaultConfig()
+	cfg.Custom.StateDir = filepath.Join(tmpDir, "state")
+	cfg.Custom.Tools = []config.CustomToolConfig{
+		{
+			Name:    "bootstrap-tool",
+			Binary:  "__sarasa_missing_binary__",
+			Missing: "install",
+			Latest:  config.CustomLatestConfig{Value: "2.0.0"},
+			Upgrade: config.CustomActionConfig{
+				Argv: []string{"sh", "-c", "printf '2.0.0' > \"$1\"", "sarasa-test", versionFile},
+			},
+			Verify: config.CustomProbeConfig{
+				Argv: []string{"cat", versionFile},
+			},
+		},
+	}
+
+	result, err := NewCustom(&Options{Config: cfg}).Upgrade(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Upgrade failed: %v", err)
+	}
+	if len(result.Upgraded) != 1 {
+		t.Fatalf("expected 1 upgraded package, got %d", len(result.Upgraded))
+	}
+	if result.Upgraded[0].Current != customNotInstalled {
+		t.Errorf("Current = %q, want %q", result.Upgraded[0].Current, customNotInstalled)
+	}
+	data, err := os.ReadFile(versionFile)
+	if err != nil {
+		t.Fatalf("read version file: %v", err)
+	}
+	if string(data) != "2.0.0" {
+		t.Errorf("version file = %q, want 2.0.0", data)
+	}
+	if _, err := os.Stat(filepath.Join(cfg.Custom.StateDir, "bootstrap-tool.json")); err != nil {
+		t.Errorf("expected state file to be written: %v", err)
+	}
+}
+
+func TestCustomMissingPolicyFail(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Custom.Tools = []config.CustomToolConfig{
+		{
+			Name:    "missing-fail",
+			Binary:  "__sarasa_missing_binary__",
+			Missing: "fail",
+			Latest:  config.CustomLatestConfig{Value: "1.0.0"},
+		},
+	}
+
+	_, err := NewCustom(&Options{Config: cfg}).CheckOutdated(context.Background())
+	if err == nil {
+		t.Fatal("expected missing fail policy to return an error")
+	}
+	if !strings.Contains(err.Error(), "missing-fail") {
+		t.Fatalf("expected error to mention tool name, got %v", err)
+	}
+}
+
+func TestCustomMissingPolicyInvalid(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Custom.Tools = []config.CustomToolConfig{
+		{
+			Name:    "missing-invalid",
+			Binary:  "__sarasa_missing_binary__",
+			Missing: "explode",
+			Latest:  config.CustomLatestConfig{Value: "1.0.0"},
+		},
+	}
+
+	_, err := NewCustom(&Options{Config: cfg}).CheckOutdated(context.Background())
+	if err == nil {
+		t.Fatal("expected invalid missing policy to return an error")
+	}
+	if !strings.Contains(err.Error(), "unknown missing policy") {
+		t.Fatalf("expected unknown policy error, got %v", err)
+	}
+}
+
+func TestLatestGitHubReleaseUsesGHToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "gh-secret")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/indrasvat/demo/releases/latest" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer gh-secret" {
+			t.Fatalf("Authorization = %q, want Bearer gh-secret", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v1.2.3"}`))
+	}))
+	defer server.Close()
+
+	oldBaseURL := githubAPIBaseURL
+	oldClient := githubHTTPClient
+	githubAPIBaseURL = server.URL
+	githubHTTPClient = server.Client()
+	t.Cleanup(func() {
+		githubAPIBaseURL = oldBaseURL
+		githubHTTPClient = oldClient
+	})
+
+	got, err := latestGitHubRelease(context.Background(), "indrasvat/demo")
+	if err != nil {
+		t.Fatalf("latestGitHubRelease failed: %v", err)
+	}
+	if got != "v1.2.3" {
+		t.Fatalf("latestGitHubRelease = %q, want v1.2.3", got)
+	}
+}
+
+func TestLatestGitHubReleaseFallsBackToGHOnForbidden(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "rate limited", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	ghPath := filepath.Join(tmpDir, "gh")
+	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\nprintf 'v9.8.7\\n'\n"), 0755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", tmpDir)
+
+	oldBaseURL := githubAPIBaseURL
+	oldClient := githubHTTPClient
+	githubAPIBaseURL = server.URL
+	githubHTTPClient = server.Client()
+	t.Cleanup(func() {
+		githubAPIBaseURL = oldBaseURL
+		githubHTTPClient = oldClient
+	})
+
+	got, err := latestGitHubRelease(context.Background(), "indrasvat/demo")
+	if err != nil {
+		t.Fatalf("latestGitHubRelease failed: %v", err)
+	}
+	if got != "v9.8.7" {
+		t.Fatalf("latestGitHubRelease = %q, want v9.8.7", got)
 	}
 }
 

--- a/go/sarasa/internal/tui/run/model.go
+++ b/go/sarasa/internal/tui/run/model.go
@@ -204,6 +204,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			result.Status = "error"
 			result.Error = msg.err
+			m.totalFailed++
 		} else {
 			result.Status = "done"
 			// Convert result packages to status
@@ -377,9 +378,13 @@ func (m Model) renderSummary() string {
 	totalDuration := time.Since(m.startTime)
 
 	if m.dryRun {
+		if m.totalFailed > 0 {
+			parts = append(parts, ui.StyleError.Render(fmt.Sprintf("%d failed", m.totalFailed)))
+		}
 		if m.totalSkipped > 0 {
 			parts = append(parts, lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#8B008B", Dark: "#DA70D6"}).Render(fmt.Sprintf("%d to upgrade", m.totalSkipped)))
-		} else {
+		}
+		if m.totalFailed == 0 && m.totalSkipped == 0 {
 			parts = append(parts, ui.StyleSuccess.Render("All up to date"))
 		}
 	} else {


### PR DESCRIPTION
## Summary
- add `missing` policy for custom sarasa recipes: default `skip`, `install` bootstrap, and `fail`
- render missing installs as `not installed → latest` and count manager errors in run summaries
- make `latest.github_release` use `GITHUB_TOKEN`/`GH_TOKEN` and fall back to authenticated `gh api` on GitHub 401/403 responses
- document the new config field and GitHub release auth behavior in both sarasa and repo READMEs

## Verification
- `make ci`
- shux dry-run screenshot: missing skip is hidden; missing install appears as `not installed → 1.2.3`
- shux fail screenshot: `missing = "fail"` shows the manager error and `1 failed` footer
- shux real run screenshot: missing install action runs and verifies `2.0.0`

## Screenshots
Will attach shux PNGs in PR comments.