### PR TITLE
fix(sarasa): space custom manager label

### DIFF
--- a/go/sarasa/internal/tui/run/model.go
+++ b/go/sarasa/internal/tui/run/model.go
@@ -301,11 +301,10 @@ func (m Model) renderManagerPanel(result *ManagerResult, width int) string {
 	var b strings.Builder
 
 	// Manager header with icon OUTSIDE the panel (with proper margin)
-	icon := ui.ManagerIcon(result.Name)
 	titleStyle := ui.GetManagerTitleStyle(result.Name)
 	title := titleStyle.Render(strings.ToUpper(result.Name))
 	headerStyle := lipgloss.NewStyle().MarginLeft(2)
-	b.WriteString(headerStyle.Render(fmt.Sprintf("%s %s", icon, title)) + "\n")
+	b.WriteString(headerStyle.Render(ui.ManagerIconLabelPrefix(result.Name)+title) + "\n")
 
 	// Panel content (no emoji inside)
 	var content strings.Builder

--- a/go/sarasa/internal/tui/status/model.go
+++ b/go/sarasa/internal/tui/status/model.go
@@ -441,11 +441,10 @@ func (m Model) renderManagerPanel(name string, status *ManagerStatus, width int)
 	var b strings.Builder
 
 	// Manager header with icon OUTSIDE the panel (with proper margin)
-	icon := ui.ManagerIcon(name)
 	titleStyle := ui.GetManagerTitleStyle(name)
 	title := titleStyle.Render(strings.ToUpper(name))
 	headerStyle := lipgloss.NewStyle().MarginLeft(2)
-	b.WriteString(headerStyle.Render(fmt.Sprintf("%s %s", icon, title)) + "\n")
+	b.WriteString(headerStyle.Render(ui.ManagerIconLabelPrefix(name)+title) + "\n")
 
 	// Panel content (no emoji inside)
 	var content strings.Builder
@@ -498,11 +497,10 @@ func (m Model) renderUpgradePanel(name string, result *upgradeResult, width int)
 	var b strings.Builder
 
 	// Manager header with icon OUTSIDE the panel (with proper margin)
-	icon := ui.ManagerIcon(name)
 	titleStyle := ui.GetManagerTitleStyle(name)
 	title := titleStyle.Render(strings.ToUpper(name))
 	headerStyle := lipgloss.NewStyle().MarginLeft(2)
-	b.WriteString(headerStyle.Render(fmt.Sprintf("%s %s", icon, title)) + "\n")
+	b.WriteString(headerStyle.Render(ui.ManagerIconLabelPrefix(name)+title) + "\n")
 
 	var content strings.Builder
 

--- a/go/sarasa/internal/ui/icons.go
+++ b/go/sarasa/internal/ui/icons.go
@@ -21,9 +21,11 @@ const (
 	IconPipx    = "🐍"
 	IconBun     = "🥟"
 	IconSkills  = "🧩"
-	IconCustom  = "🛠"
+	IconCustom  = "🛠️"
 	IconPackage = "📦"
 )
+
+const managerCustom = "custom"
 
 // ManagerIcon returns the icon for a given manager name.
 func ManagerIcon(name string) string {
@@ -40,11 +42,17 @@ func ManagerIcon(name string) string {
 		return IconBun
 	case "skills":
 		return IconSkills
-	case "custom":
+	case managerCustom:
 		return IconCustom
 	default:
 		return IconPackage
 	}
+}
+
+// ManagerIconLabelPrefix returns the icon plus the terminal-cell gap before a
+// styled manager label.
+func ManagerIconLabelPrefix(name string) string {
+	return ManagerIcon(name) + " "
 }
 
 // PlainManagerIcon returns a plain text indicator for non-TTY output.

--- a/go/sarasa/internal/ui/icons_test.go
+++ b/go/sarasa/internal/ui/icons_test.go
@@ -1,0 +1,12 @@
+package ui
+
+import "testing"
+
+func TestManagerIconLabelPrefix(t *testing.T) {
+	if got := ManagerIconLabelPrefix("skills"); got != IconSkills+" " {
+		t.Fatalf("skills prefix = %q, want one-cell gap", got)
+	}
+	if got := ManagerIconLabelPrefix(managerCustom); got != IconCustom+" " {
+		t.Fatalf("custom prefix = %q, want one-cell gap", got)
+	}
+}

--- a/go/sarasa/internal/ui/styles.go
+++ b/go/sarasa/internal/ui/styles.go
@@ -39,7 +39,7 @@ func ManagerColor(name string) lipgloss.AdaptiveColor {
 		return ColorBun
 	case "skills":
 		return ColorSkills
-	case "custom":
+	case managerCustom:
 		return ColorCustom
 	default:
 		return ColorPrimary


### PR DESCRIPTION
## Summary
- Render the custom manager icon with emoji presentation so the label spacing matches other managers across platforms.
- Share manager header prefix rendering between run/status TUI paths.
- Add a unit test for manager icon label prefixes.

## Verification
- make check
- shux-driven full sarasa run dry-run captured locally: go/sarasa/.shux/out/custom-label/full-run-tui-spacing-emoji.png

## Notes
- Native shux PNG snapshot currently drops emoji glyphs even though pane capture contains them; the sarasa output itself emits the expected Unicode.