### PR TITLE
fix(sarasa): include custom in help

### DIFF
--- a/go/sarasa/cmd/root.go
+++ b/go/sarasa/cmd/root.go
@@ -23,7 +23,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "sarasa",
 	Short: "Automated global package manager upgrades",
-	Long: `Sarasa automates global package upgrades for brew, volta/npm, bun, pipx, and skills
+	Long: `Sarasa automates global package upgrades for brew, volta/npm, bun, pipx, skills, and custom tools
 with scheduled background execution via launchd.
 
 Uses volta when detected, otherwise falls back to npm.
@@ -141,6 +141,7 @@ func styledHelp(cmd *cobra.Command, args []string) {
 			{ui.IconPipx, "pipx", ui.ColorPipx},
 			{ui.IconBun, "bun", ui.ColorBun},
 			{ui.IconSkills, "skills", ui.ColorSkills},
+			{ui.IconCustom, "custom", ui.ColorCustom},
 		}
 		b.WriteString("  ")
 		for i, m := range managers {
@@ -154,7 +155,7 @@ func styledHelp(cmd *cobra.Command, args []string) {
 		b.WriteString(mutedStyle.Render("  (uses volta when detected, otherwise npm)"))
 		b.WriteString("\n")
 	} else {
-		b.WriteString("  brew · volta · npm · pipx · bun · skills\n")
+		b.WriteString("  brew · volta · npm · pipx · bun · skills · custom\n")
 		b.WriteString("  (uses volta when detected, otherwise npm)\n")
 	}
 	b.WriteString("\n")

--- a/go/sarasa/cmd/root_test.go
+++ b/go/sarasa/cmd/root_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRootHelpIncludesCustomManager(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+	})
+
+	styledHelp(rootCmd, nil)
+	help := out.String()
+
+	if !strings.Contains(rootCmd.Long, "custom tools") {
+		t.Fatalf("root long description should mention custom tools: %q", rootCmd.Long)
+	}
+
+	const managers = "brew · volta · npm · pipx · bun · skills · custom"
+	if !strings.Contains(help, managers) {
+		t.Fatalf("root help should include custom manager list %q, got:\n%s", managers, help)
+	}
+}


### PR DESCRIPTION
## Summary

- add the custom manager to the root `sarasa --help` manager list in styled and plain output
- update the root long description to mention custom tools
- add a regression test covering the root help manager list

## Checks

- `go test ./...`
- `go test ./cmd -run TestRootHelpIncludesCustomManager -v`
- `go build -o sarasa .`
- `./sarasa --help`
- `go vet ./...`
- `make lint`
- pre-push `make ci` via lefthook: shell lint, Python lint, Go lint, `go test -v -race ./...`

## Screenshot

A color `shux` screenshot of `sarasa --help` will be attached in a PR comment.