### PR TITLE
feat(sarasa): add run json and launchd path

### DIFF
--- a/go/sarasa/.shux/scripts/capture-custom-dry-run.sh
+++ b/go/sarasa/.shux/scripts/capture-custom-dry-run.sh
@@ -39,7 +39,7 @@ TOML
 
 shux session kill "${SESSION}" >/dev/null 2>&1 || true
 shux --format json session create "${SESSION}" -d -- \
-    env -u NO_COLOR TERM=xterm-256color "${BINARY}" --config "${CONFIG}" run --dry-run >/dev/null
+    env -u NO_COLOR TERM=xterm-256color COLORTERM=truecolor "${BINARY}" --config "${CONFIG}" run --dry-run >/dev/null
 
 shux pane set-size -s "${SESSION}" --cols 110 --rows 30 >/dev/null
 shux pane wait-for -s "${SESSION}" --text "CUSTOM" --timeout-ms 10000 >/dev/null

--- a/go/sarasa/.shux/scripts/capture-run-dry-run.sh
+++ b/go/sarasa/.shux/scripts/capture-run-dry-run.sh
@@ -22,7 +22,7 @@ fi
 args+=(run --dry-run)
 
 shux --format json session create "${SESSION}" -d -- \
-    env -u NO_COLOR TERM=xterm-256color "${args[@]}" >/dev/null
+    env -u NO_COLOR TERM=xterm-256color COLORTERM=truecolor "${args[@]}" >/dev/null
 
 shux pane set-size -s "${SESSION}" --cols 100 --rows 34 >/dev/null
 shux pane wait-for -s "${SESSION}" --text "SARASA DRY RUN" --timeout-ms 10000 >/dev/null

--- a/go/sarasa/.shux/scripts/capture-run-json.sh
+++ b/go/sarasa/.shux/scripts/capture-run-json.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SESSION="${SESSION:-sarasa-run-json}"
+OUT_DIR="${ROOT}/.shux/out/run-json"
+BINARY="${BINARY:-${ROOT}/sarasa}"
+CONFIG="${OUT_DIR}/run-json-demo-config.toml"
+
+mkdir -p "${OUT_DIR}"
+
+if [[ ! -x "${BINARY}" ]]; then
+    (cd "${ROOT}" && go build -o sarasa .)
+fi
+
+cat > "${CONFIG}" <<'TOML'
+managers = ["custom"]
+
+[custom]
+state_dir = "~/.local/state/sarasa/run-json-demo"
+default_timeout = "30s"
+
+[[custom.tools]]
+name = "json-demo"
+current = { argv = ["sh", "-c", "printf 'json-demo v1.0.0'"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
+latest = { value = "v1.1.0" }
+upgrade = { shell = "printf 'installing ${name} ${current} -> ${latest}'" }
+verify = { argv = ["sh", "-c", "printf 'json-demo v1.1.0'"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
+TOML
+
+shux session kill "${SESSION}" >/dev/null 2>&1 || true
+shux --format json session create "${SESSION}" -d -- \
+    env -u NO_COLOR TERM=xterm-256color COLORTERM=truecolor "${BINARY}" --config "${CONFIG}" run --dry-run --json >/dev/null
+
+shux pane set-size -s "${SESSION}" --cols 120 --rows 34 >/dev/null
+shux pane wait-for -s "${SESSION}" --text '"dry_run": true' --timeout-ms 10000 >/dev/null
+shux pane wait-for -s "${SESSION}" --text '"would_upgrade"' --timeout-ms 10000 >/dev/null
+sleep "${SETTLE_SECONDS:-1}"
+
+shux pane capture -s "${SESSION}" > "${OUT_DIR}/sarasa-run-json.txt"
+shux --format json pane snapshot -s "${SESSION}" \
+    | jq -r .png_base64 \
+    | base64 -d > "${OUT_DIR}/sarasa-run-json.png"
+
+grep -q '"success": true' "${OUT_DIR}/sarasa-run-json.txt"
+grep -q '"name": "json-demo"' "${OUT_DIR}/sarasa-run-json.txt"
+
+shux session kill "${SESSION}" >/dev/null
+
+printf '%s\n' "${OUT_DIR}/sarasa-run-json.png"

--- a/go/sarasa/README.md
+++ b/go/sarasa/README.md
@@ -21,9 +21,42 @@ managers and user-defined tools that are installed outside package managers.
 sarasa init
 sarasa status
 sarasa run --dry-run
+sarasa run --json
 sarasa run
 sarasa logs
 sarasa schedule install
+```
+
+`sarasa run --json` always uses non-interactive output, even when stdout is a
+TTY. Dry-run candidates are reported under `would_upgrade`.
+
+Example:
+
+```json
+{
+  "dry_run": true,
+  "success": true,
+  "summary": {
+    "upgraded": 0,
+    "failed": 0,
+    "skipped": 0,
+    "would_upgrade": 1
+  },
+  "managers": [
+    {
+      "name": "custom",
+      "available": true,
+      "would_upgrade": [
+        {
+          "name": "demo-tool",
+          "current": "v1.0.0",
+          "latest": "v1.1.0",
+          "method": "pinned / shell"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 ## Configuration
@@ -46,6 +79,10 @@ custom = ["experimental-tool"]
 [schedule]
 times = ["08:00", "14:00", "22:00"]
 ```
+
+Scheduled launchd runs use an explicit PATH that includes the directory
+containing the Sarasa binary, `~/.local/bin`, `~/bin`, `~/go/bin`, the current
+PATH at schedule install time, and the standard macOS system paths.
 
 ## Custom Tools
 
@@ -218,4 +255,5 @@ Visual checks use shux so TUI rendering is verified in a real PTY:
 ```bash
 .shux/scripts/capture-run-dry-run.sh
 .shux/scripts/capture-custom-dry-run.sh
+.shux/scripts/capture-run-json.sh
 ```

--- a/go/sarasa/cmd/init.go
+++ b/go/sarasa/cmd/init.go
@@ -156,10 +156,11 @@ func applyInitResult(result wizard.Result) error {
 
 		binaryPath, _ := os.Executable()
 		launchdCfg := &scheduler.Config{
-			Label:      scheduler.LaunchAgentLabel,
-			BinaryPath: binaryPath,
-			LogDir:     cfg.Logging.Dir,
-			Times:      times,
+			Label:           scheduler.LaunchAgentLabel,
+			BinaryPath:      binaryPath,
+			LogDir:          cfg.Logging.Dir,
+			Times:           times,
+			EnvironmentPath: scheduler.DefaultEnvironmentPath(binaryPath),
 		}
 
 		if err := scheduler.Install(launchdCfg); err != nil {

--- a/go/sarasa/cmd/root.go
+++ b/go/sarasa/cmd/root.go
@@ -217,6 +217,7 @@ func styledHelp(cmd *cobra.Command, args []string) {
 	}{
 		{"sarasa status", "Show outdated packages (press u to upgrade)"},
 		{"sarasa run --dry-run", "Preview upgrades without applying"},
+		{"sarasa run --json", "Run upgrades with machine-readable output"},
 		{"sarasa run", "Upgrade all outdated packages"},
 		{"sarasa logs", "View upgrade history"},
 		{"sarasa schedule install", "Enable scheduled upgrades via launchd"},

--- a/go/sarasa/cmd/run.go
+++ b/go/sarasa/cmd/run.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -21,6 +24,7 @@ var (
 	runDryRun      bool
 	runNoMajor     bool
 	runSkipCleanup bool
+	runJSON        bool
 )
 
 var runCmd = &cobra.Command{
@@ -32,9 +36,11 @@ Examples:
   sarasa run                          # Run all available managers
   sarasa run --managers=brew,pipx     # Run specific managers
   sarasa run --dry-run                # Show what would be upgraded
+  sarasa run --json                   # Output machine-readable JSON
   sarasa run --no-major               # Skip major version upgrades (npm)
-  sarasa run --skip-cleanup           # Skip cleanup phase`,
-	RunE: runRun,
+	sarasa run --skip-cleanup           # Skip cleanup phase`,
+	RunE:         runRun,
+	SilenceUsage: true,
 }
 
 func init() {
@@ -44,6 +50,38 @@ func init() {
 	runCmd.Flags().BoolVar(&runDryRun, "dry-run", false, "show what would be upgraded without making changes")
 	runCmd.Flags().BoolVar(&runNoMajor, "no-major", false, "skip major version upgrades (npm only)")
 	runCmd.Flags().BoolVar(&runSkipCleanup, "skip-cleanup", false, "skip cleanup phase")
+	runCmd.Flags().BoolVar(&runJSON, "json", false, "output as JSON")
+}
+
+// RunOutput is the JSON result envelope for sarasa run.
+type RunOutput struct {
+	DryRun     bool               `json:"dry_run"`
+	Success    bool               `json:"success"`
+	DurationMs int64              `json:"duration_ms"`
+	Summary    RunSummary         `json:"summary"`
+	Managers   []RunManagerResult `json:"managers"`
+}
+
+// RunSummary contains aggregate run counts.
+type RunSummary struct {
+	Upgraded      int `json:"upgraded"`
+	Failed        int `json:"failed"`
+	Skipped       int `json:"skipped"`
+	WouldUpgrade  int `json:"would_upgrade,omitempty"`
+	ManagerErrors int `json:"manager_errors,omitempty"`
+}
+
+// RunManagerResult contains one manager's run outcome.
+type RunManagerResult struct {
+	Name         string            `json:"name"`
+	Available    bool              `json:"available"`
+	DurationMs   int64             `json:"duration_ms,omitempty"`
+	Upgraded     []manager.Package `json:"upgraded,omitempty"`
+	Failed       []manager.Package `json:"failed,omitempty"`
+	Skipped      []manager.Package `json:"skipped,omitempty"`
+	WouldUpgrade []manager.Package `json:"would_upgrade,omitempty"`
+	Error        string            `json:"error,omitempty"`
+	CleanupError string            `json:"cleanup_error,omitempty"`
 }
 
 func runRun(_ *cobra.Command, _ []string) error {
@@ -70,6 +108,19 @@ func runRun(_ *cobra.Command, _ []string) error {
 		managerNames = manager.List()
 	}
 
+	log.Info("Starting sarasa run",
+		"managers", managerNames,
+		"dry_run", runDryRun,
+	)
+
+	// Wrap config to implement ManagerConfigProvider interface
+	cfgWrapper := &configWrapper{cfg: cfg}
+
+	// JSON output is always non-interactive, even when stdout is a TTY.
+	if runJSON {
+		return runRunJSON(managerNames, opts, cfgWrapper, os.Stdout)
+	}
+
 	// Get managers
 	managers, err := manager.GetMultiple(managerNames, opts)
 	if err != nil {
@@ -82,16 +133,8 @@ func runRun(_ *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	log.Info("Starting sarasa run",
-		"managers", managerNames,
-		"dry_run", runDryRun,
-	)
-
 	// Detect output mode
 	mode := ui.DetectOutputMode()
-
-	// Wrap config to implement ManagerConfigProvider interface
-	cfgWrapper := &configWrapper{cfg: cfg}
 
 	switch mode {
 	case ui.ModeTUI:
@@ -100,6 +143,93 @@ func runRun(_ *cobra.Command, _ []string) error {
 		return runRunPlain(managers, opts, cfgWrapper, mode == ui.ModeStyled)
 	}
 
+	return nil
+}
+
+func runRunJSON(managerNames []string, opts *manager.Options, cfg *configWrapper, writer io.Writer) error {
+	ctx, cancel := signal.NotifyContext(context.Background())
+	defer cancel()
+
+	output := RunOutput{
+		DryRun:   opts.DryRun,
+		Success:  true,
+		Managers: make([]RunManagerResult, 0, len(managerNames)),
+	}
+	overallStart := time.Now()
+
+	for _, name := range managerNames {
+		result := RunManagerResult{Name: name}
+
+		m, err := manager.Get(name, opts)
+		if err != nil {
+			result.Error = err.Error()
+			output.Success = false
+			output.Summary.ManagerErrors++
+			output.Managers = append(output.Managers, result)
+			continue
+		}
+
+		result.Available = m.IsAvailable()
+		if !result.Available {
+			output.Managers = append(output.Managers, result)
+			continue
+		}
+
+		opts.SkipList = cfg.GetSkipList(name)
+		logger.LogStart(m.Name())
+		start := time.Now()
+		upgradeResult, err := m.Upgrade(ctx, opts.DryRun)
+		result.DurationMs = time.Since(start).Milliseconds()
+		if err != nil {
+			result.Error = err.Error()
+			output.Success = false
+			output.Summary.ManagerErrors++
+			logger.LogComplete(m.Name(), 0, 1, result.DurationMs)
+			output.Managers = append(output.Managers, result)
+			continue
+		}
+		if upgradeResult == nil {
+			upgradeResult = &manager.UpgradeResult{}
+		}
+
+		result.Upgraded = upgradeResult.Upgraded
+		result.Failed = upgradeResult.Failed
+		if opts.DryRun {
+			result.WouldUpgrade = upgradeResult.Skipped
+			output.Summary.WouldUpgrade += len(upgradeResult.Skipped)
+		} else {
+			result.Skipped = upgradeResult.Skipped
+			output.Summary.Skipped += len(upgradeResult.Skipped)
+		}
+		output.Summary.Upgraded += len(upgradeResult.Upgraded)
+		output.Summary.Failed += len(upgradeResult.Failed)
+		if len(upgradeResult.Failed) > 0 {
+			output.Success = false
+		}
+
+		if !opts.DryRun && !opts.SkipCleanup {
+			if err := m.Cleanup(ctx); err != nil {
+				result.CleanupError = err.Error()
+				output.Success = false
+				output.Summary.ManagerErrors++
+			}
+		}
+
+		logger.LogComplete(m.Name(), len(upgradeResult.Upgraded), len(upgradeResult.Failed), result.DurationMs)
+		output.Managers = append(output.Managers, result)
+	}
+
+	output.DurationMs = time.Since(overallStart).Milliseconds()
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(writer, string(data)); err != nil {
+		return err
+	}
+	if !output.Success {
+		return fmt.Errorf("sarasa run completed with failures")
+	}
 	return nil
 }
 

--- a/go/sarasa/cmd/run_test.go
+++ b/go/sarasa/cmd/run_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/indrasvat/sarasa/internal/config"
+	"github.com/indrasvat/sarasa/internal/manager"
+)
+
+type fakeRunManager struct {
+	name       string
+	upgrade    *manager.UpgradeResult
+	upgradeErr error
+	cleanupErr error
+	available  bool
+	skipList   []string
+}
+
+func (f *fakeRunManager) Name() string { return f.name }
+
+func (f *fakeRunManager) IsAvailable() bool { return f.available }
+
+func (f *fakeRunManager) CheckOutdated(context.Context) ([]manager.Package, error) {
+	return nil, nil
+}
+
+func (f *fakeRunManager) Upgrade(context.Context, bool) (*manager.UpgradeResult, error) {
+	if f.upgradeErr != nil {
+		return nil, f.upgradeErr
+	}
+	return f.upgrade, nil
+}
+
+func (f *fakeRunManager) Cleanup(context.Context) error { return f.cleanupErr }
+
+func (f *fakeRunManager) SetSkipList(packages []string) { f.skipList = packages }
+
+func TestRunJSONDryRunUsesWouldUpgrade(t *testing.T) {
+	name := "test-run-json-dry"
+	manager.Register(name, func(*manager.Options) manager.Manager {
+		return &fakeRunManager{
+			name:      name,
+			available: true,
+			upgrade: &manager.UpgradeResult{
+				Skipped: []manager.Package{{
+					Name:    "demo",
+					Current: "1.0.0",
+					Latest:  "1.1.0",
+				}},
+			},
+		}
+	})
+
+	cfg := config.DefaultConfig()
+	var out bytes.Buffer
+	err := runRunJSON(
+		[]string{name},
+		&manager.Options{DryRun: true, Config: cfg},
+		&configWrapper{cfg: cfg},
+		&out,
+	)
+	if err != nil {
+		t.Fatalf("runRunJSON() error = %v", err)
+	}
+
+	var got RunOutput
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out.String())
+	}
+	if !got.DryRun || !got.Success {
+		t.Fatalf("unexpected envelope: %+v", got)
+	}
+	if got.Summary.WouldUpgrade != 1 {
+		t.Fatalf("Summary.WouldUpgrade = %d, want 1", got.Summary.WouldUpgrade)
+	}
+	if len(got.Managers) != 1 || len(got.Managers[0].WouldUpgrade) != 1 {
+		t.Fatalf("missing would_upgrade package: %+v", got.Managers)
+	}
+	if len(got.Managers[0].Skipped) != 0 {
+		t.Fatalf("dry-run JSON should expose skipped as would_upgrade, got %+v", got.Managers[0].Skipped)
+	}
+}
+
+func TestRunJSONReportsManagerFailures(t *testing.T) {
+	name := "test-run-json-failure"
+	manager.Register(name, func(*manager.Options) manager.Manager {
+		return &fakeRunManager{
+			name:       name,
+			available:  true,
+			upgradeErr: errors.New("upgrade failed"),
+		}
+	})
+
+	cfg := config.DefaultConfig()
+	var out bytes.Buffer
+	err := runRunJSON(
+		[]string{name},
+		&manager.Options{Config: cfg},
+		&configWrapper{cfg: cfg},
+		&out,
+	)
+	if err == nil {
+		t.Fatal("runRunJSON() error = nil, want failure")
+	}
+
+	var got RunOutput
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out.String())
+	}
+	if got.Success {
+		t.Fatalf("Success = true, want false: %+v", got)
+	}
+	if got.Summary.ManagerErrors != 1 {
+		t.Fatalf("ManagerErrors = %d, want 1", got.Summary.ManagerErrors)
+	}
+	if len(got.Managers) != 1 || got.Managers[0].Error != "upgrade failed" {
+		t.Fatalf("missing manager error: %+v", got.Managers)
+	}
+}
+
+func TestRunCommandHasJSONFlag(t *testing.T) {
+	if runCmd.Flags().Lookup("json") == nil {
+		t.Fatal("run command missing --json flag")
+	}
+}

--- a/go/sarasa/cmd/schedule.go
+++ b/go/sarasa/cmd/schedule.go
@@ -14,6 +14,10 @@ var scheduleCmd = &cobra.Command{
 	Short: "Manage scheduled upgrades",
 	Long: `Manage launchd-based scheduled upgrades.
 
+Scheduled runs use a generated non-interactive launchd environment with a PATH
+that includes user-local tool directories such as ~/.local/bin, ~/bin, and
+~/go/bin, plus the directory containing the sarasa binary.
+
 Examples:
   sarasa schedule install             # Install launchd agent
   sarasa schedule uninstall           # Remove launchd agent
@@ -63,10 +67,11 @@ func runScheduleInstall(_ *cobra.Command, _ []string) error {
 	}
 
 	launchdCfg := &scheduler.Config{
-		Label:      scheduler.LaunchAgentLabel,
-		BinaryPath: binaryPath,
-		LogDir:     cfg.Logging.Dir,
-		Times:      times,
+		Label:           scheduler.LaunchAgentLabel,
+		BinaryPath:      binaryPath,
+		LogDir:          cfg.Logging.Dir,
+		Times:           times,
+		EnvironmentPath: scheduler.DefaultEnvironmentPath(binaryPath),
 	}
 
 	if err := scheduler.Install(launchdCfg); err != nil {

--- a/go/sarasa/internal/scheduler/launchd.go
+++ b/go/sarasa/internal/scheduler/launchd.go
@@ -54,7 +54,7 @@ const (
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>{{.EnvironmentPath}}</string>
     </dict>
 </dict>
 </plist>`
@@ -68,10 +68,11 @@ type ScheduleTime struct {
 
 // Config holds launchd configuration.
 type Config struct {
-	Label      string
-	BinaryPath string
-	LogDir     string
-	Times      []ScheduleTime
+	Label           string
+	BinaryPath      string
+	LogDir          string
+	Times           []ScheduleTime
+	EnvironmentPath string
 }
 
 // PlistPath returns the path to the launchd plist file.
@@ -128,9 +129,10 @@ func DefaultConfig() (*Config, error) {
 	}
 
 	return &Config{
-		Label:      LaunchAgentLabel,
-		BinaryPath: binaryPath,
-		LogDir:     filepath.Join(homeDir, "Library", "Logs", "sarasa"),
+		Label:           LaunchAgentLabel,
+		BinaryPath:      binaryPath,
+		LogDir:          filepath.Join(homeDir, "Library", "Logs", "sarasa"),
+		EnvironmentPath: DefaultEnvironmentPath(binaryPath),
 		Times: []ScheduleTime{
 			{Hour: 0, Minute: 0},
 			{Hour: 2, Minute: 0},
@@ -148,6 +150,47 @@ func DefaultConfig() (*Config, error) {
 	}, nil
 }
 
+// DefaultEnvironmentPath returns a launchd-safe PATH for scheduled sarasa runs.
+//
+// launchd jobs do not inherit the user's interactive shell PATH. Sarasa custom
+// tools are commonly installed in user-local directories, so include those
+// explicitly along with the directory containing the sarasa binary.
+func DefaultEnvironmentPath(binaryPath string) string {
+	homeDir, _ := os.UserHomeDir()
+	candidates := []string{}
+	if dir := filepath.Dir(binaryPath); binaryPath != "" && dir != "." {
+		candidates = append(candidates, dir)
+	}
+	if homeDir != "" {
+		candidates = append(candidates,
+			filepath.Join(homeDir, ".local", "bin"),
+			filepath.Join(homeDir, "bin"),
+			filepath.Join(homeDir, "go", "bin"),
+		)
+	}
+	candidates = append(candidates, filepath.SplitList(os.Getenv("PATH"))...)
+	candidates = append(candidates,
+		"/opt/homebrew/bin",
+		"/usr/local/bin",
+		"/usr/bin",
+		"/bin",
+		"/usr/sbin",
+		"/sbin",
+	)
+
+	seen := make(map[string]bool, len(candidates))
+	path := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || !filepath.IsAbs(candidate) || seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+		path = append(path, candidate)
+	}
+	return strings.Join(path, ":")
+}
+
 // GeneratePlist generates the launchd plist content.
 func GeneratePlist(cfg *Config) ([]byte, error) {
 	tmpl, err := template.New("plist").Parse(plistTemplate)
@@ -155,8 +198,13 @@ func GeneratePlist(cfg *Config) ([]byte, error) {
 		return nil, fmt.Errorf("failed to parse plist template: %w", err)
 	}
 
+	renderCfg := *cfg
+	if renderCfg.EnvironmentPath == "" {
+		renderCfg.EnvironmentPath = DefaultEnvironmentPath(renderCfg.BinaryPath)
+	}
+
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, cfg); err != nil {
+	if err := tmpl.Execute(&buf, &renderCfg); err != nil {
 		return nil, fmt.Errorf("failed to execute plist template: %w", err)
 	}
 

--- a/go/sarasa/internal/scheduler/launchd_test.go
+++ b/go/sarasa/internal/scheduler/launchd_test.go
@@ -1,0 +1,61 @@
+package scheduler
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultEnvironmentPathIncludesUserLocalAndBinaryDir(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "tools", "bin")
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "/usr/bin:/bin:/usr/bin")
+
+	got := DefaultEnvironmentPath(filepath.Join(binDir, "sarasa"))
+	parts := strings.Split(got, ":")
+
+	wantPrefix := []string{
+		binDir,
+		filepath.Join(home, ".local", "bin"),
+		filepath.Join(home, "bin"),
+		filepath.Join(home, "go", "bin"),
+	}
+	if len(parts) < len(wantPrefix) {
+		t.Fatalf("PATH too short: %q", got)
+	}
+	for i, want := range wantPrefix {
+		if parts[i] != want {
+			t.Fatalf("PATH[%d] = %q, want %q in %q", i, parts[i], want, got)
+		}
+	}
+
+	if strings.Count(got, "/usr/bin") != 1 {
+		t.Fatalf("expected /usr/bin to be deduplicated once in %q", got)
+	}
+}
+
+func TestGeneratePlistRendersConfiguredEnvironmentPath(t *testing.T) {
+	plist, err := GeneratePlist(&Config{
+		Label:           LaunchAgentLabel,
+		BinaryPath:      "/tmp/sarasa",
+		LogDir:          "/tmp/logs",
+		EnvironmentPath: "/tmp/bin:/usr/bin:/bin",
+		Times:           []ScheduleTime{{Hour: 9, Minute: 30}},
+	})
+	if err != nil {
+		t.Fatalf("GeneratePlist() error = %v", err)
+	}
+
+	text := string(plist)
+	for _, want := range []string{
+		"<string>/tmp/sarasa</string>",
+		"<integer>9</integer>",
+		"<integer>30</integer>",
+		"<string>/tmp/bin:/usr/bin:/bin</string>",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("plist missing %q:\n%s", want, text)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add non-interactive JSON output for `sarasa run`
- generate launchd schedules with a user-local PATH for custom tools
- document and verify the new behavior with unit tests and Shux captures

## Validation
- `make check`
- `.shux/scripts/capture-custom-dry-run.sh`
- `.shux/scripts/capture-run-json.sh`
