### PR TITLE
feat(airdrop-autoheal): self-healing awdl0 AirDrop LaunchDaemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-shell install-python install-go uninstall lint lint-shell lint-python lint-go list ci test hooks tools tools-ci
+.PHONY: help install install-shell install-airdrop-autoheal install-python install-go uninstall lint lint-shell lint-python lint-go list ci test hooks tools tools-ci
 
 SHELL := /bin/bash
 BIN_DIR := $(HOME)/.local/bin
@@ -47,6 +47,9 @@ install-go: ## Build and install Go tools
 	@cd $(CURDIR)/go/sarasa && go build -o $(BIN_DIR)/sarasa .
 	@echo -e "  $(GREEN)✓$(NC) Go tools built and installed"
 
+install-airdrop-autoheal: ## Install the AirDrop auto-heal LaunchDaemon (needs sudo; not part of `make install`)
+	@sudo bash $(CURDIR)/shell/airdrop-autoheal/install.sh
+
 uninstall: ## Remove installed scripts from ~/.local/bin
 	@echo "Removing installed scripts..."
 	@rm -f $(BIN_DIR)/iterm2-screenshot
@@ -89,6 +92,8 @@ list: ## List all available scripts
 	@ls -1 shell/utilities/*.sh 2>/dev/null | xargs -I{} basename {} .sh | sed 's/^/    /'
 	@echo "  dev-setup/"
 	@ls -1 shell/dev-setup/*.sh 2>/dev/null | xargs -I{} basename {} .sh | sed 's/^/    /'
+	@echo "  airdrop-autoheal/"
+	@echo "    airdrop-autoheal (LaunchDaemon -- make install-airdrop-autoheal)"
 	@echo ""
 	@echo -e "$(CYAN)Python Scripts$(NC)"
 	@echo "  automation/"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A curated collection of useful scripts for macOS automation, development setup, 
 ```
 .
 ├── shell/
+│   ├── airdrop-autoheal/    # Self-healing LaunchDaemon for the awdl0 AirDrop flake
 │   ├── screenshot-tools/    # Terminal screenshot automation
 │   ├── dev-setup/           # Development environment setup scripts
 │   └── utilities/           # General-purpose utilities
@@ -97,6 +98,21 @@ Two-script workflow for cloning your dev environment across Macs.
 # Watch kubectl and notify on changes
 ./watch-and-notify.sh kubectl get po --watch --no-headers
 ```
+
+### AirDrop Auto-Heal
+
+[`airdrop-autoheal/`](shell/airdrop-autoheal/) is a root `LaunchDaemon` that self-heals the macOS **`awdl0` AirDrop path-migration flake** — the intermittent failure where a transfer is accepted, then dies mid-flight because macOS migrates the connection off the `awdl0` peer-to-peer link (common with a VPN like Tailscale running). It watches `sharingd`'s log and re-primes `awdl0` within ~1s so your re-send succeeds.
+
+```bash
+# Install (auto-elevates with sudo, verifies with doctor):
+curl -fsSL https://raw.githubusercontent.com/indrasvat/kitchen-sink/main/shell/airdrop-autoheal/install.sh | sudo bash
+
+# Health report (no sudo) + manual reset
+bash "/Library/Application Support/airdrop-autoheal/doctor.sh"
+sudo "/Library/Application Support/airdrop-autoheal/airdrop-autoheal.sh" --bounce-once
+```
+
+Hardened across two adversarial reviews (no orphaned processes, PID-reuse guard, circuit breaker, never leaves `awdl0` down). See [`shell/airdrop-autoheal/README.md`](shell/airdrop-autoheal/README.md) for the safety design.
 
 ## Python Scripts
 

--- a/shell/airdrop-autoheal/README.md
+++ b/shell/airdrop-autoheal/README.md
@@ -1,0 +1,85 @@
+# AirDrop Auto-Heal
+
+A root `LaunchDaemon` that self-heals the macOS **`awdl0` AirDrop path-migration
+flake** — the intermittent failure where an AirDrop transfer is accepted, then
+dies mid-flight because macOS migrates the connection **off** the `awdl0`
+peer-to-peer link to a "better path" (common when a VPN like Tailscale is
+running). The daemon watches `sharingd`'s log for the exact failure fingerprint
+and re-primes `awdl0` within ~1s, so your re-send goes straight through.
+
+It is **auto-recovery, not prevention**: it can't rescue the transfer that just
+died, but it clears the wedge so the retry succeeds — with zero manual steps.
+
+## Install
+
+```bash
+# One-liner (any Mac) — auto-elevates with sudo:
+curl -fsSL https://raw.githubusercontent.com/indrasvat/kitchen-sink/main/shell/airdrop-autoheal/install.sh | sudo bash
+
+# From a local clone:
+sudo bash shell/airdrop-autoheal/install.sh
+
+# Check prerequisites only (no sudo):
+bash shell/airdrop-autoheal/install.sh --check
+```
+
+The installer is idempotent, verifies itself with `doctor` at the end, and
+needs root exactly **once** (to install a LaunchDaemon and because bouncing a
+network interface is a privileged operation). After that it runs autonomously —
+no further `sudo` prompts.
+
+## Commands
+
+| Command | Root? | What it does |
+| --- | --- | --- |
+| `bash "/Library/Application Support/airdrop-autoheal/doctor.sh"` | no | Darcula-themed health report (process tree, orphan scan, predicate, awdl0, logs) |
+| `sudo "/Library/Application Support/airdrop-autoheal/airdrop-autoheal.sh" --bounce-once` | yes | Manual one-shot `awdl0` reset (hotkey-able) |
+| `sudo tail -f /var/log/airdrop-autoheal.log` | no¹ | Watch every detection + bounce live |
+| `sudo bash install.sh --uninstall` | yes | Unload + remove (keeps logs) |
+
+¹ The audit log is `0640 root:admin` — readable without `sudo` if you're in the
+`admin` group.
+
+## How it works
+
+- **Detection:** a backgrounded `log stream` watches for
+  `processImagePath == "/usr/libexec/sharingd" AND eventMessage CONTAINS "quic_migration_path_unavailable" AND CONTAINS "awdl0"`.
+  Pinning the real Apple binary by path (not the spoofable process *name*) means
+  no unprivileged process can forge the trigger.
+- **Heal:** `ifconfig awdl0 down/up` re-primes the AWDL link.
+- **Safety (hardened across two adversarial reviews):**
+  - log stream is a **directly-backgrounded** child read via a FIFO in the
+    root-only install dir — the trap kills exactly its PID (guarded against PID
+    reuse), so **no orphaned process or subshell** is ever left behind.
+  - signals `exit` explicitly (never resume mid-bounce); the EXIT trap always
+    forces `awdl0` back **up** (never wedged down), with retries.
+  - **circuit breaker** caps bounces at 6 / 600s so it can never thrash the network.
+  - pinned `PATH` + absolute binaries; logs `0640` + `newsyslog`-rotated;
+    hourly heartbeat line so the log self-documents liveness.
+- **Footprint:** ~0% CPU/mem at idle (a single narrow `log stream` subscriber).
+
+## What it installs
+
+```
+/Library/Application Support/airdrop-autoheal/airdrop-autoheal.sh   # watcher daemon
+/Library/Application Support/airdrop-autoheal/doctor.sh             # health report
+/Library/LaunchDaemons/com.indrasvat.airdrop-autoheal.plist        # KeepAlive daemon
+/etc/newsyslog.d/airdrop-autoheal.conf                             # log rotation
+/var/log/airdrop-autoheal.{log,err}                                # audit logs (0640)
+```
+
+## What this does NOT fix
+
+A separate, unrelated AirDrop-receive failure on **macOS Tahoe** throws
+`NSPOSIXErrorDomain Code 2 "No such file or directory"` at finalization when the
+incoming **filename contains non-ASCII characters** (e.g. `ā`, `·`). That's an
+Apple OS bug in path handling — not a network issue — so this daemon correctly
+does nothing for it. Workaround: rename to ASCII before sending; report via
+Feedback Assistant.
+
+## Requirements
+
+- **macOS** (uses `launchctl` / `sharingd` / `awdl0`).
+- Runs under system `/bin/bash` (3.2-compatible by design — no dependency on a
+  newer shell).
+- Root once for install; none thereafter.

--- a/shell/airdrop-autoheal/airdrop-autoheal.sh
+++ b/shell/airdrop-autoheal/airdrop-autoheal.sh
@@ -116,14 +116,16 @@ while :; do
   if IFS= read -r -t "$HEARTBEAT" line <&3; then
     :   # got a line — fall through to process it
   else
-    # read failed: idle-timeout OR stream death. Distinguish by stream liveness
-    # (NOT by $?, which is 1 for both on /bin/bash 3.2).
-    if kill -0 "$STREAM_PID" 2>/dev/null; then
+    # read failed: idle-timeout (stream alive) vs stream death. Distinguish by
+    # the stream's process STATE — NOT `kill -0`, which is fooled by an unreaped
+    # zombie (a dead child still "exists"), spinning this loop and spamming the
+    # log. State "Z" (zombie) or empty (reaped/gone) both mean the stream died.
+    sstate="$(ps -p "$STREAM_PID" -o state= 2>/dev/null | cut -c1)"
+    if [ -n "$sstate" ] && [ "$sstate" != "Z" ]; then
       note "heartbeat — watching (awdl0 $(status), bounces this window ${breaker_count})"
       continue
-    else
-      break   # stream is gone → exit for relaunch
     fi
+    break   # stream dead/zombie → exit non-zero for launchd to relaunch
   fi
 
   case "$line" in

--- a/shell/airdrop-autoheal/airdrop-autoheal.sh
+++ b/shell/airdrop-autoheal/airdrop-autoheal.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# airdrop-autoheal — watch the unified log for the AirDrop awdl0 path-migration
+# failure fingerprint and re-prime awdl0. Runs as a root LaunchDaemon.
+#   (no args)      run as the daemon
+#   --bounce-once  one manual reset (root)   — also your hotkey-able reset
+# Health/diagnostics: run  doctor.sh  (installed alongside).
+#
+# Robustness (each verified by test):
+#  - log stream is a DIRECTLY-backgrounded child with a known PID, read via a
+#    FIFO in the ROOT-ONLY install dir (not world-writable /tmp). The trap kills
+#    exactly that PID — guarded against PID reuse — so NO orphan is ever left.
+#  - predicate pins the real Apple binary (processImagePath) — unspoofable.
+#  - signals exit explicitly (never resume mid-bounce); EXIT trap forces awdl0 UP
+#    with retries (never wedged down).
+#  - heartbeat distinguishes idle-timeout from stream-death via `kill -0`, so it
+#    is correct on /bin/bash 3.2 (where `read -t` timeout returns 1, like EOF).
+#  - circuit breaker caps bounces/window; pinned PATH + absolute binaries.
+set -euo pipefail
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+IFCONFIG=/sbin/ifconfig
+LOGBIN=/usr/bin/log
+AWK=/usr/bin/awk
+DATE=/bin/date
+
+LOG=/var/log/airdrop-autoheal.log
+APPDIR="/Library/Application Support/airdrop-autoheal"   # root-only (0755 root:wheel)
+IFACE=awdl0
+COOLDOWN=30                 # min seconds between bounces
+BREAKER_MAX=6               # at most this many bounces ...
+BREAKER_WINDOW=600          # ... per this many seconds, else pause (circuit breaker)
+HEARTBEAT=3600              # log a liveness line every N idle seconds
+PRED='processImagePath == "/usr/libexec/sharingd" AND eventMessage CONTAINS "quic_migration_path_unavailable" AND eventMessage CONTAINS "awdl0"'
+
+last_bounce=0
+breaker_start=0
+breaker_count=0
+STREAM_PID=""
+FIFO=""
+
+ts()   { "$DATE" '+%Y-%m-%d %H:%M:%S'; }
+note() { printf '%s  %s\n' "$(ts)" "$*" >>"$LOG" 2>/dev/null || true; }
+
+# Bring awdl0 up, with retries. Shared by bounce() and cleanup().
+force_up() {
+  "$IFCONFIG" "$IFACE" up >/dev/null 2>&1 && return 0
+  for _ in 1 2 3; do
+    sleep 1
+    "$IFCONFIG" "$IFACE" up >/dev/null 2>&1 && return 0
+  done
+  return 1
+}
+
+# Kill ONLY our own stream child (guarded against PID reuse), then leave awdl0 up.
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() {
+  if [ -n "${STREAM_PID:-}" ] && kill -0 "$STREAM_PID" 2>/dev/null; then
+    if [ "$(ps -p "$STREAM_PID" -o ppid= 2>/dev/null | tr -d ' ')" = "$$" ]; then
+      kill "$STREAM_PID" 2>/dev/null || true
+      wait "$STREAM_PID" 2>/dev/null || true
+    fi
+  fi
+  [ -n "${FIFO:-}" ] && rm -f "$FIFO" 2>/dev/null || true
+  force_up || true
+}
+
+# single quotes intentional: $2 is an awk field, not a shell variable.
+# shellcheck disable=SC2016
+status() { "$IFCONFIG" "$IFACE" 2>/dev/null | "$AWK" '/^[[:space:]]*status:/{print $2; exit}' || true; }
+
+bounce() {
+  local before after
+  before=$(status)
+  if ! "$IFCONFIG" "$IFACE" down 2>>"$LOG"; then
+    note "ERROR: '$IFACE down' failed — leaving interface as-is"
+    return 1
+  fi
+  sleep 1
+  if ! force_up; then
+    note "FATAL: $IFACE may be left DOWN after retries — exiting for launchd to recover"
+    exit 1
+  fi
+  sleep 1
+  after=$(status)
+  note "BOUNCED $IFACE  (status ${before:-?} -> ${after:-?})"
+  return 0
+}
+
+# ---- one-shot manual reset (root): minimal trap (just ensure awdl0 up) ----
+if [ "${1:-}" = "--bounce-once" ]; then
+  if [ "$(id -u)" -ne 0 ]; then echo "must be root: sudo $0 --bounce-once" >&2; exit 1; fi
+  trap 'force_up || true' EXIT
+  trap 'exit 143' INT TERM HUP
+  note "manual --bounce-once invoked"
+  bounce || true
+  exit 0
+fi
+
+# ---- daemon ----
+# cleanup runs once on EXIT; signals trigger an explicit exit (which fires the
+# EXIT trap), so a TERM/HUP during startup or a bounce never RESUMES the script.
+trap cleanup EXIT
+trap 'exit 143' INT TERM HUP
+
+# FIFO in the root-only install dir + unique name: an unprivileged user cannot
+# pre-create it (no /tmp DoS), and the unique name avoids any multi-instance race.
+FIFO="$(mktemp -u "${APPDIR}/stream.XXXXXX")" || { note "FATAL: mktemp failed"; exit 1; }
+if ! mkfifo -m 0600 "$FIFO" 2>>"$LOG"; then note "FATAL: mkfifo $FIFO failed"; exit 1; fi
+"$LOGBIN" stream --style compact --predicate "$PRED" >"$FIFO" 2>>"$LOG" &
+STREAM_PID=$!
+exec 3<"$FIFO"
+
+note "=== airdrop-autoheal started (pid $$, stream $STREAM_PID, cooldown ${COOLDOWN}s, breaker ${BREAKER_MAX}/${BREAKER_WINDOW}s) ==="
+
+while :; do
+  if IFS= read -r -t "$HEARTBEAT" line <&3; then
+    :   # got a line — fall through to process it
+  else
+    # read failed: idle-timeout OR stream death. Distinguish by stream liveness
+    # (NOT by $?, which is 1 for both on /bin/bash 3.2).
+    if kill -0 "$STREAM_PID" 2>/dev/null; then
+      note "heartbeat — watching (awdl0 $(status), bounces this window ${breaker_count})"
+      continue
+    else
+      break   # stream is gone → exit for relaunch
+    fi
+  fi
+
+  case "$line" in
+    *quic_migration_path_unavailable*) : ;;
+    *) continue ;;
+  esac
+
+  now=$("$DATE" +%s)
+  if [ "$((now - last_bounce))" -lt "$COOLDOWN" ]; then
+    note "failure seen (within ${COOLDOWN}s cooldown) — skipping"
+    continue
+  fi
+  if [ "$((now - breaker_start))" -ge "$BREAKER_WINDOW" ]; then
+    breaker_start=$now
+    breaker_count=0
+  fi
+  if [ "$breaker_count" -ge "$BREAKER_MAX" ]; then
+    note "CIRCUIT BREAKER tripped (>=${BREAKER_MAX} bounces / ${BREAKER_WINDOW}s) — NOT bouncing; investigate"
+    continue
+  fi
+  last_bounce=$now
+  breaker_count=$((breaker_count + 1))
+  note "DETECTED AirDrop awdl0 path-migration failure (#${breaker_count} this window)"
+  bounce || note "bounce returned non-zero"
+done
+
+note "=== log stream ended (stream $STREAM_PID gone) — exiting non-zero for launchd relaunch ==="
+exit 1

--- a/shell/airdrop-autoheal/airdrop-autoheal.sh
+++ b/shell/airdrop-autoheal/airdrop-autoheal.sh
@@ -92,8 +92,8 @@ if [ "${1:-}" = "--bounce-once" ]; then
   trap 'force_up || true' EXIT
   trap 'exit 143' INT TERM HUP
   note "manual --bounce-once invoked"
-  bounce || true
-  exit 0
+  bounce          # propagate status so a hotkey/script sees a reset that failed
+  exit $?         # (the EXIT trap still forces awdl0 back up regardless)
 fi
 
 # ---- daemon ----

--- a/shell/airdrop-autoheal/com.indrasvat.airdrop-autoheal.plist
+++ b/shell/airdrop-autoheal/com.indrasvat.airdrop-autoheal.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.indrasvat.airdrop-autoheal</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Library/Application Support/airdrop-autoheal/airdrop-autoheal.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+    <key>ProcessType</key>
+    <string>Background</string>
+    <key>StandardErrorPath</key>
+    <string>/var/log/airdrop-autoheal.err</string>
+</dict>
+</plist>

--- a/shell/airdrop-autoheal/doctor.sh
+++ b/shell/airdrop-autoheal/doctor.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# airdrop-autoheal doctor — one-shot health + diagnostics report (Darcula-themed).
+# Run:  sudo bash doctor.sh        (root gives full detail; runs without too)
+#   --no-color / NO_COLOR=1        force plain output
+# Exit code = number of FAILs (0 = healthy).
+set -uo pipefail
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+LABEL=com.indrasvat.airdrop-autoheal
+LOG=/var/log/airdrop-autoheal.log
+ERR=/var/log/airdrop-autoheal.err
+APPDIR="/Library/Application Support/airdrop-autoheal"
+BIN="$APPDIR/airdrop-autoheal.sh"
+PLIST="/Library/LaunchDaemons/${LABEL}.plist"
+NEWSYSLOG="/etc/newsyslog.d/airdrop-autoheal.conf"
+PRED='processImagePath == "/usr/libexec/sharingd" AND eventMessage CONTAINS "quic_migration_path_unavailable" AND eventMessage CONTAINS "awdl0"'
+BW=60   # rule width (single source of truth)
+
+# ---- Darcula palette (24-bit truecolor); auto-off when not a TTY / NO_COLOR ----
+# Precedence: NO_COLOR / --no-color always win; FORCE_COLOR enables off a TTY;
+# otherwise auto-detect (color only when stdout is a terminal).
+want_color=0
+[ -t 1 ] && want_color=1
+[ -n "${FORCE_COLOR:-}" ] && want_color=1
+[ -n "${NO_COLOR:-}" ] && want_color=0
+[ "${1:-}" = "--no-color" ] && want_color=0
+if [ "$want_color" = 1 ]; then
+  R=$'\033[0m'; B=$'\033[1m'; DIM=$'\033[2m'
+  FG=$'\033[38;2;169;183;198m'    # #A9B7C6 foreground
+  GRY=$'\033[38;2;128;128;128m'   # #808080 comment gray
+  ORG=$'\033[38;2;204;120;50m'    # #CC7832 keyword orange
+  YEL=$'\033[38;2;255;198;109m'   # #FFC66D function yellow
+  GRN=$'\033[38;2;152;195;121m'   # bright green
+  BLU=$'\033[38;2;104;151;187m'   # #6897BB number blue
+  RED=$'\033[38;2;255;107;104m'   # #FF6B68 error red
+  CYN=$'\033[38;2;88;157;175m'    # teal accent
+  WHT=$'\033[38;2;240;240;240m'
+  INK=$'\033[38;2;30;30;30m'      # dark ink for filled badges
+  BG_GRN=$'\033[48;2;106;135;89m'; BG_YEL=$'\033[48;2;204;120;50m'; BG_RED=$'\033[48;2;188;63;60m'
+else
+  R=''; B=''; DIM=''; FG=''; GRY=''; ORG=''; YEL=''; GRN=''; BLU=''; RED=''; CYN=''; WHT=''; INK=''
+  BG_GRN=''; BG_YEL=''; BG_RED=''
+fi
+
+pass=0; warn=0; fail=0
+
+rule()    { local i s=""; for ((i=0; i<BW; i++)); do s="${s}${1:-━}"; done; printf '%b%s%b\n' "$CYN" "$s" "$R"; }
+section() { printf '\n  %b❯%b %b%b%s%b\n' "$ORG" "$R" "$B" "$FG" "$1" "$R"; }
+ok()   { printf '    %b%b OK   %b %b%s%b\n' "$B$BG_GRN" "$INK" "$R" "$FG"  "$*" "$R"; pass=$((pass + 1)); }
+wn()   { printf '    %b%b WARN %b %b%s%b\n' "$B$BG_YEL" "$INK" "$R" "$YEL" "$*" "$R"; warn=$((warn + 1)); }
+bad()  { printf '    %b%b FAIL %b %b%s%b\n' "$B$BG_RED" "$WHT" "$R" "$RED" "$*" "$R"; fail=$((fail + 1)); }
+dimblk(){ printf '%b' "$GRY"; sed 's/^/         /'; printf '%b' "$R"; }   # dim a stdin block
+
+# ---- header ----
+echo
+rule "━"
+printf '   %b%bairdrop-autoheal%b %b·%b %b%bdoctor%b\n' "$ORG" "$B" "$R" "$GRY" "$R" "$CYN" "$B" "$R"
+rule "━"
+if [ "$(id -u)" -eq 0 ]; then modes="${GRN}root${R}"; else modes="${DIM}non-root — sudo for full detail${R}"; fi
+printf '   %btime%b %b%s%b  %b·%b  %buser%b %b%s%b  %b·%b  %b\n' \
+  "$GRY" "$R" "$BLU" "$(date '+%Y-%m-%d %H:%M:%S')" "$R" "$GRY" "$R" \
+  "$GRY" "$R" "$FG" "$(id -un)" "$R" "$GRY" "$R" "$modes"
+
+# ---- install ----
+section "install"
+if [ -f "$BIN" ]; then ok "watcher present"; else bad "watcher MISSING: $BIN"; fi
+if [ -f "$PLIST" ]; then ok "plist present"; else bad "plist MISSING: $PLIST"; fi
+if [ -f "$NEWSYSLOG" ]; then ok "log rotation configured"; else wn "no newsyslog config — logs may grow unbounded"; fi
+
+# ---- launchd job ----
+section "launchd job"
+if info=$(launchctl print "system/${LABEL}" 2>/dev/null); then
+  st=$(printf '%s\n'   "$info" | awk -F'= ' '/[ \t]state = /{print $2; exit}')
+  jpid=$(printf '%s\n' "$info" | awk -F'= ' '/[ \t]pid = /{print $2; exit}')
+  runs=$(printf '%s\n' "$info" | awk -F'= ' '/[ \t]runs = /{print $2; exit}')
+  if [ "$st" = "running" ]; then ok "job running (pid ${jpid:-?}, runs ${runs:-?})"; else wn "job state: ${st:-unknown} (pid ${jpid:-none})"; fi
+  case "${runs:-}" in ''|*[!0-9]*) : ;; *) [ "$runs" -gt 20 ] && wn "high restart count (runs=${runs}) — possible flapping";; esac
+else
+  wn "cannot query launchd job (need sudo) — checking processes directly"
+fi
+
+# ---- process tree ----
+section "process tree"
+# note: `ps -o comm=` may print a full path (e.g. /usr/bin/log) on macOS, so
+# normalize with basename before comparing.
+mainpid=""
+for p in $(pgrep -f "airdrop-autoheal/airdrop-autoheal.sh" 2>/dev/null); do
+  cb=$(basename "$(ps -p "$p" -o comm= 2>/dev/null)" 2>/dev/null)
+  pp=$(ps -p "$p" -o ppid= 2>/dev/null | tr -d ' ')
+  [ "$cb" = "bash" ] && [ "$pp" = "1" ] && mainpid="$p"
+done
+if [ -n "$mainpid" ]; then
+  ok "daemon main loop alive (pid $mainpid)"
+  logchild=""
+  for c in $(pgrep -P "$mainpid" 2>/dev/null); do
+    [ "$(basename "$(ps -p "$c" -o comm= 2>/dev/null)" 2>/dev/null)" = "log" ] && logchild="$c"
+  done
+  if [ -n "$logchild" ]; then ok "log stream child alive (pid $logchild) — actively watching"; else bad "no log stream child — daemon may be wedged / not watching"; fi
+else
+  bad "daemon main loop NOT running"
+fi
+
+# ---- orphan scan ----
+section "orphan scan (must be empty)"
+# shellcheck disable=SC2009  # need ppid + full command line together; pgrep can't filter on both
+orphans=$(ps -axo pid,ppid,comm,command 2>/dev/null \
+  | grep "processImagePath" | grep -v grep \
+  | grep -viE "skycomputer|codex|doctor|SharedSupport|claude" \
+  | awk -v m="${mainpid:-0}" '$3 ~ /(^|\/)log$/ && $2!=m {print $1}')
+if [ -z "$orphans" ]; then ok "no orphaned log-stream processes"; else for o in $orphans; do bad "ORPHAN log stream pid=$o (parent != daemon)"; done; fi
+
+# ---- predicate ----
+section "detection predicate"
+if log show --last 1m --predicate "$PRED" >/dev/null 2>&1; then ok "predicate parses & is accepted by log(1)"; else bad "predicate REJECTED by log(1)"; fi
+
+# ---- awdl0 ----
+section "awdl0"
+aw=$(ifconfig awdl0 2>/dev/null | awk '/status:/{print $2}')
+if [ "$aw" = "active" ]; then ok "awdl0 status: active"; else wn "awdl0 status: ${aw:-MISSING}"; fi
+
+# ---- audit log ----
+section "audit log"
+if [ -r "$LOG" ]; then
+  sz=$(stat -f '%z' "$LOG" 2>/dev/null)
+  nb=$(grep -c "BOUNCED awdl0" "$LOG" 2>/dev/null || true); nb=${nb:-0}
+  ok "log readable (${sz} bytes, ${nb} total bounces)"
+  lh=$(grep "heartbeat" "$LOG" 2>/dev/null | tail -1); [ -n "$lh" ] && printf '%b         last heartbeat: %s%b\n' "$GRY" "$lh" "$R"
+  printf '         %blast 6 events:%b\n' "$DIM" "$R"
+  tail -n 6 "$LOG" 2>/dev/null | dimblk
+else
+  wn "audit log not readable here (try: sudo bash doctor.sh): $LOG"
+fi
+if [ -r "$ERR" ]; then
+  es=$(stat -f '%z' "$ERR" 2>/dev/null)
+  case "${es:-0}" in 0) ok "stderr clean (0 bytes)";; *) wn "stderr non-empty (${es}B) — inspect $ERR"; tail -n 3 "$ERR" 2>/dev/null | dimblk;; esac
+fi
+
+# ---- resource use ----
+section "resource use"
+[ -n "$mainpid" ] && ps -p "$mainpid" -o pid,pcpu,pmem,etime,comm 2>/dev/null | dimblk
+
+# ---- summary ----
+echo
+rule "━"
+if [ "$fail" -eq 0 ]; then vbg="$BG_GRN"; vink="$INK"; verdict="HEALTHY"; else vbg="$BG_RED"; vink="$WHT"; verdict="NEEDS ATTENTION"; fi
+printf '  %b%b %s %b   %b%d OK%b   %b%d WARN%b   %b%d FAIL%b\n' \
+  "$B$vbg" "$vink" "$verdict" "$R" "$GRN" "$pass" "$R" "$YEL" "$warn" "$R" "$RED" "$fail" "$R"
+echo
+exit "$fail"

--- a/shell/airdrop-autoheal/install.sh
+++ b/shell/airdrop-autoheal/install.sh
@@ -190,16 +190,17 @@ NSL
     local i
     for i in $(seq 1 20); do launchctl print "system/${LABEL}" >/dev/null 2>&1 || break; sleep 0.5; done
     launchctl enable "system/${LABEL}" 2>/dev/null || true
-    local bs_ok=0
+    # Capture stderr in a variable — no predictable /tmp file for a root process
+    # to be tricked (symlink/TOCTOU) into clobbering.
+    local bs_ok=0 bs_err=""
     for i in 1 2 3 4 5; do
-        if launchctl bootstrap system "$PLIST" 2>/tmp/airdrop-bs.err; then bs_ok=1; break; fi
+        if bs_err="$(launchctl bootstrap system "$PLIST" 2>&1)"; then bs_ok=1; break; fi
         launchctl bootout "system/${LABEL}" 2>/dev/null || true; sleep 1
     done
     if [ "$bs_ok" -ne 1 ]; then
-        _fail "bootstrap failed:"; sed 's/^/        /' /tmp/airdrop-bs.err 2>/dev/null || true
-        rm -f /tmp/airdrop-bs.err; exit 1
+        _fail "bootstrap failed:"; printf '%s\n' "$bs_err" | sed 's/^/        /'
+        exit 1
     fi
-    rm -f /tmp/airdrop-bs.err
     launchctl kickstart -k "system/${LABEL}" 2>/dev/null || true
     _done "Daemon loaded"
 }

--- a/shell/airdrop-autoheal/install.sh
+++ b/shell/airdrop-autoheal/install.sh
@@ -69,6 +69,9 @@ _done() { printf "  %s│%s  %s✔%s %s\n" "${DIM}${CYN}" "$RST" "$BGRN" "$RST" 
 _warn() { printf "  %s│%s  %s⚠  %s%s\n" "${DIM}${CYN}" "$RST" "$BYEL" "$*" "$RST"; }
 _fail() { printf "  %s│%s  %s✘%s %s\n" "${DIM}${CYN}" "$RST" "$RED" "$RST" "$*"; }
 _step() { printf "  %s│%s  %s▶%s %s\n" "${DIM}${CYN}" "$RST" "$BCYN" "$RST" "$*"; }
+# Run a command that MUST succeed; abort (no half-installed state). The script
+# can't use `set -e` — its many `[ cond ] && action` lines would abort spuriously.
+_must() { "$@" || { _fail "failed: $*"; exit 1; }; }
 
 cleanup() { [ -n "$CLEANUP_DIR" ] && [ -d "$CLEANUP_DIR" ] && rm -rf "$CLEANUP_DIR"; }
 trap cleanup EXIT INT TERM
@@ -163,25 +166,29 @@ locate_artifacts() {
 do_install() {
     _step "Installing files (root-owned)…"
     # Root-only dir (NOT /usr/local/bin — admin-writable script run by root = LPE).
-    install -d -m 0755 -o root -g wheel "$APPDIR"
-    install -m 0755 -o root -g wheel "$SRC_DIR/airdrop-autoheal.sh" "$APPDIR/airdrop-autoheal.sh"
-    install -m 0755 -o root -g wheel "$SRC_DIR/doctor.sh"           "$APPDIR/doctor.sh"
-    install -m 0644 -o root -g wheel "$SRC_DIR/${LABEL}.plist"      "$PLIST"
+    _must install -d -m 0755 -o root -g wheel "$APPDIR"
+    _must install -m 0755 -o root -g wheel "$SRC_DIR/airdrop-autoheal.sh" "$APPDIR/airdrop-autoheal.sh"
+    _must install -m 0755 -o root -g wheel "$SRC_DIR/doctor.sh"           "$APPDIR/doctor.sh"
+    _must install -m 0644 -o root -g wheel "$SRC_DIR/${LABEL}.plist"      "$PLIST"
 
     # Private (non-world-readable) audit logs.
     local f
     for f in "$LOGF" "$ERRF"; do
-        [ -e "$f" ] || : >"$f"
-        chown root:admin "$f"; chmod 0640 "$f"
+        if [ ! -e "$f" ]; then : >"$f" || { _fail "cannot create $f"; exit 1; }; fi
+        _must chown root:admin "$f"
+        _must chmod 0640 "$f"
     done
 
     # Bound growth via newsyslog (rotate ~1MB, keep 7, bzip2).
-    cat >"$NEWSYSLOG" <<'NSL'
+    if ! cat >"$NEWSYSLOG" <<'NSL'
 # logfilename                     [owner:group]  mode  count  size  when  flags
 /var/log/airdrop-autoheal.log     root:admin     640   7      1024  *     J
 /var/log/airdrop-autoheal.err     root:admin     640   7      1024  *     J
 NSL
-    chmod 0644 "$NEWSYSLOG"
+    then
+        _fail "cannot write $NEWSYSLOG"; exit 1
+    fi
+    _must chmod 0644 "$NEWSYSLOG"
     _done "Files installed"
 
     _step "Loading LaunchDaemon…"

--- a/shell/airdrop-autoheal/install.sh
+++ b/shell/airdrop-autoheal/install.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+# ╭──────────────────────────────────────────────────────────────╮
+# │  AirDrop Auto-Heal Installer                                 │
+# │  Self-healing LaunchDaemon for the macOS awdl0 AirDrop flake  │
+# │  Seamless · auto-elevates with sudo · verifies with doctor    │
+# ╰──────────────────────────────────────────────────────────────╯
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/indrasvat/kitchen-sink/main/shell/airdrop-autoheal/install.sh | sudo bash
+#   sudo bash install.sh                 # local install (from a clone)
+#   bash  install.sh                     # auto re-execs itself with sudo
+#   sudo bash install.sh --uninstall     # remove the daemon
+#   bash  install.sh --check             # prerequisites only (no sudo)
+#
+# Installs (root):
+#   /Library/Application Support/airdrop-autoheal/airdrop-autoheal.sh   (watcher)
+#   /Library/Application Support/airdrop-autoheal/doctor.sh             (health)
+#   /Library/LaunchDaemons/com.indrasvat.airdrop-autoheal.plist
+#   /var/log/airdrop-autoheal.{log,err}   + newsyslog rotation
+set -uo pipefail
+
+# ── Configuration ───────────────────────────────────────────────
+LABEL="com.indrasvat.airdrop-autoheal"
+APPDIR="/Library/Application Support/airdrop-autoheal"
+PLIST="/Library/LaunchDaemons/${LABEL}.plist"
+NEWSYSLOG="/etc/newsyslog.d/airdrop-autoheal.conf"
+LOGF="/var/log/airdrop-autoheal.log"
+ERRF="/var/log/airdrop-autoheal.err"
+REPO_URL="https://github.com/indrasvat/kitchen-sink.git"
+REPO_SUBDIR="shell/airdrop-autoheal"
+
+ACTION="install"
+SRC_DIR=""
+CLEANUP_DIR=""
+ORIG_ARGS=("$@")
+
+# ── Colors ──────────────────────────────────────────────────────
+want_color=0
+[ -t 1 ] && want_color=1
+[ -n "${FORCE_COLOR:-}" ] && want_color=1
+[ -n "${NO_COLOR:-}" ] && want_color=0
+for a in ${ORIG_ARGS[@]+"${ORIG_ARGS[@]}"}; do [ "$a" = "--no-color" ] && want_color=0; done
+if [ "$want_color" = 1 ]; then
+    RST=$'\033[0m'; DIM=$'\033[2m'; BOLD=$'\033[1m'
+    RED=$'\033[31m'; CYN=$'\033[36m'
+    BGRN=$'\033[92m'; BCYN=$'\033[96m'; BYEL=$'\033[93m'
+else
+    RST=""; DIM=""; BOLD=""; RED=""; CYN=""; BGRN=""; BCYN=""; BYEL=""
+fi
+
+# ── Box-drawing (BW = inner width; content auto-padded) ─────────
+BW=56
+_box_rule() {
+    local left="$1" right="$2" fill="" i
+    for ((i = 0; i < BW; i++)); do fill="${fill}─"; done
+    printf "  %s%s%s%s%s\n" "$CYN" "$left" "$fill" "$right" "$RST"
+}
+# Measure display width on the ANSI-stripped string (never ${#styled}).
+_box_line() {
+    local content="$*" plain pad spaces="" i
+    plain="$(printf '%s' "$content" | sed $'s/\033\[[0-9;]*m//g')"
+    pad=$((BW - 1 - ${#plain}))
+    [ "$pad" -lt 0 ] && pad=0
+    for ((i = 0; i < pad; i++)); do spaces="${spaces} "; done
+    printf "  %s│%s %s%s%s│%s\n" "$CYN" "$RST" "$content" "$spaces" "$CYN" "$RST"
+}
+_info() { printf "  %s│%s  %s▸%s %s\n" "${DIM}${CYN}" "$RST" "$CYN" "$RST" "$*"; }
+_done() { printf "  %s│%s  %s✔%s %s\n" "${DIM}${CYN}" "$RST" "$BGRN" "$RST" "$*"; }
+_warn() { printf "  %s│%s  %s⚠  %s%s\n" "${DIM}${CYN}" "$RST" "$BYEL" "$*" "$RST"; }
+_fail() { printf "  %s│%s  %s✘%s %s\n" "${DIM}${CYN}" "$RST" "$RED" "$RST" "$*"; }
+_step() { printf "  %s│%s  %s▶%s %s\n" "${DIM}${CYN}" "$RST" "$BCYN" "$RST" "$*"; }
+
+cleanup() { [ -n "$CLEANUP_DIR" ] && [ -d "$CLEANUP_DIR" ] && rm -rf "$CLEANUP_DIR"; }
+trap cleanup EXIT INT TERM
+
+# ── Argument parsing ────────────────────────────────────────────
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --uninstall) ACTION="uninstall" ;;
+        --check)     ACTION="check" ;;
+        --no-color)  : ;;
+        --help | -h)
+            printf "Usage: [sudo] bash %s [--uninstall] [--check] [--no-color]\n" "$0"
+            printf "\n  (no flags)    install + load the auto-heal LaunchDaemon (needs root)\n"
+            printf "  --uninstall   unload + remove it (needs root)\n"
+            printf "  --check       check prerequisites only (no root)\n"
+            printf "  --no-color    plain output\n"
+            exit 0
+            ;;
+        *) printf "%sUnknown option: %s%s\n" "$RED" "$1" "$RST" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+show_banner() {
+    printf "\n"
+    _box_rule "╭" "╮"; _box_line ""
+    _box_line "${BOLD}AIRDROP AUTO-HEAL${RST}"
+    _box_line ""
+    _box_line "Self-heals the macOS awdl0 AirDrop transfer flake"
+    _box_line "${DIM}watch sharingd / re-prime awdl0 / zero-touch${RST}"
+    _box_line ""; _box_rule "╰" "╯"; printf "\n"
+}
+
+# ── Root handling: auto-elevate for install/uninstall ───────────
+ensure_root() {
+    [ "$(id -u)" -eq 0 ] && return 0
+    local self="${BASH_SOURCE[0]:-}"
+    if [ -n "$self" ] && [ -f "$self" ]; then
+        _warn "Root needed (LaunchDaemon + awdl0 control) — re-running with sudo…"
+        printf "\n"
+        exec sudo -- /bin/bash "$self" ${ORIG_ARGS[@]+"${ORIG_ARGS[@]}"}
+    fi
+    _fail "Root required, and I can't re-exec from a pipe. Re-run with sudo:"
+    _info "  curl -fsSL <…>/install.sh | ${BOLD}sudo${RST} bash"
+    exit 1
+}
+
+# ── Prerequisites ───────────────────────────────────────────────
+check_prereqs() {
+    local ok="true"
+    _step "Checking prerequisites…"; printf "\n"
+
+    if [ "$(uname -s)" = "Darwin" ]; then _done "macOS ${DIM}($(sw_vers -productVersion 2>/dev/null || echo '?'))${RST}"
+    else _fail "macOS only (uname=$(uname -s))"; ok="false"; fi
+
+    if [ -x /usr/libexec/sharingd ]; then _done "AirDrop daemon ${DIM}(/usr/libexec/sharingd)${RST}"
+    else _fail "/usr/libexec/sharingd not found — is this macOS?"; ok="false"; fi
+
+    if command -v launchctl >/dev/null 2>&1; then _done "launchctl present"; else _fail "launchctl not found"; ok="false"; fi
+    if [ -x /sbin/ifconfig ]; then _done "ifconfig present"; else _fail "/sbin/ifconfig not found"; ok="false"; fi
+
+    if /sbin/ifconfig awdl0 >/dev/null 2>&1; then _done "awdl0 interface present"
+    else _warn "awdl0 not present right now (created on demand by AirDrop) — continuing"; fi
+
+    printf "\n"
+    [ "$ok" = "true" ] || { _fail "Prerequisites not met."; return 1; }
+    return 0
+}
+
+# ── Locate artifacts: local clone, else sparse-fetch ────────────
+locate_artifacts() {
+    local self="${BASH_SOURCE[0]:-}" dir=""
+    [ -n "$self" ] && [ -f "$self" ] && dir="$(cd "$(dirname "$self")" && pwd)"
+    if [ -n "$dir" ] && [ -f "$dir/airdrop-autoheal.sh" ] && [ -f "$dir/doctor.sh" ] && [ -f "$dir/${LABEL}.plist" ]; then
+        SRC_DIR="$dir"
+        _done "Using local artifacts ${DIM}(${dir})${RST}"
+        return 0
+    fi
+    command -v git >/dev/null 2>&1 || { _fail "git required to fetch artifacts"; exit 1; }
+    local tmp; tmp="$(mktemp -d "${TMPDIR:-/tmp}/airdrop-autoheal-install.XXXXXX")"; CLEANUP_DIR="$tmp"
+    _step "Fetching artifacts (sparse checkout)…"
+    if ! git clone --depth 1 --filter=blob:none --sparse "$REPO_URL" "$tmp/repo" >/dev/null 2>&1; then
+        _fail "git clone failed"; exit 1
+    fi
+    git -C "$tmp/repo" sparse-checkout set "$REPO_SUBDIR" >/dev/null 2>&1
+    SRC_DIR="$tmp/repo/$REPO_SUBDIR"
+    [ -f "$SRC_DIR/airdrop-autoheal.sh" ] || { _fail "artifacts missing after clone"; exit 1; }
+    _done "Artifacts fetched"
+}
+
+# ── Install ─────────────────────────────────────────────────────
+do_install() {
+    _step "Installing files (root-owned)…"
+    # Root-only dir (NOT /usr/local/bin — admin-writable script run by root = LPE).
+    install -d -m 0755 -o root -g wheel "$APPDIR"
+    install -m 0755 -o root -g wheel "$SRC_DIR/airdrop-autoheal.sh" "$APPDIR/airdrop-autoheal.sh"
+    install -m 0755 -o root -g wheel "$SRC_DIR/doctor.sh"           "$APPDIR/doctor.sh"
+    install -m 0644 -o root -g wheel "$SRC_DIR/${LABEL}.plist"      "$PLIST"
+
+    # Private (non-world-readable) audit logs.
+    local f
+    for f in "$LOGF" "$ERRF"; do
+        [ -e "$f" ] || : >"$f"
+        chown root:admin "$f"; chmod 0640 "$f"
+    done
+
+    # Bound growth via newsyslog (rotate ~1MB, keep 7, bzip2).
+    cat >"$NEWSYSLOG" <<'NSL'
+# logfilename                     [owner:group]  mode  count  size  when  flags
+/var/log/airdrop-autoheal.log     root:admin     640   7      1024  *     J
+/var/log/airdrop-autoheal.err     root:admin     640   7      1024  *     J
+NSL
+    chmod 0644 "$NEWSYSLOG"
+    _done "Files installed"
+
+    _step "Loading LaunchDaemon…"
+    # bootout is ASYNC — wait for full unload before bootstrap, else EIO (error 5).
+    launchctl bootout "system/${LABEL}" 2>/dev/null || true
+    local i
+    for i in $(seq 1 20); do launchctl print "system/${LABEL}" >/dev/null 2>&1 || break; sleep 0.5; done
+    launchctl enable "system/${LABEL}" 2>/dev/null || true
+    local bs_ok=0
+    for i in 1 2 3 4 5; do
+        if launchctl bootstrap system "$PLIST" 2>/tmp/airdrop-bs.err; then bs_ok=1; break; fi
+        launchctl bootout "system/${LABEL}" 2>/dev/null || true; sleep 1
+    done
+    if [ "$bs_ok" -ne 1 ]; then
+        _fail "bootstrap failed:"; sed 's/^/        /' /tmp/airdrop-bs.err 2>/dev/null || true
+        rm -f /tmp/airdrop-bs.err; exit 1
+    fi
+    rm -f /tmp/airdrop-bs.err
+    launchctl kickstart -k "system/${LABEL}" 2>/dev/null || true
+    _done "Daemon loaded"
+}
+
+# ── Uninstall ───────────────────────────────────────────────────
+do_uninstall() {
+    _step "Removing LaunchDaemon…"
+    launchctl bootout "system/${LABEL}" 2>/dev/null || true
+    rm -f "$PLIST" "$NEWSYSLOG"
+    rm -rf "$APPDIR"
+    /sbin/ifconfig awdl0 up >/dev/null 2>&1 || true   # never leave awdl0 down
+    _done "Removed (logs kept at /var/log/airdrop-autoheal.{log,err})"
+}
+
+# ── Verify (run the installed doctor) ───────────────────────────
+verify() {
+    _step "Verifying with doctor…"; printf "\n"
+    sleep 3   # let the daemon write its start line + spawn the log child
+    if [ -x "$APPDIR/doctor.sh" ]; then
+        /bin/bash "$APPDIR/doctor.sh" || true
+    fi
+}
+
+# ── Post-action boxes ───────────────────────────────────────────
+post_install() {
+    printf "\n"; _box_rule "╭" "╮"; _box_line ""
+    _box_line "${BGRN}OK${RST}  ${BOLD}Installed - auto-heal is live${RST}"
+    _box_line ""; _box_rule "╰" "╯"; printf "\n"
+    # Long absolute paths live OUTSIDE the box (no right border to align to).
+    _info "Health  ${BOLD}bash \"${APPDIR}/doctor.sh\"${RST}"
+    _info "Logs    ${BOLD}sudo tail -f ${LOGF}${RST}"
+    _info "Reset   ${BOLD}sudo \"${APPDIR}/airdrop-autoheal.sh\" --bounce-once${RST}"
+    _info "Remove  ${BOLD}sudo bash install.sh --uninstall${RST}"
+    printf "\n"
+}
+post_uninstall() {
+    printf "\n"; _box_rule "╭" "╮"; _box_line ""
+    _box_line "${BGRN}OK${RST} ${BOLD}Uninstalled${RST}"
+    _box_line ""; _box_rule "╰" "╯"; printf "\n"
+}
+
+# ── Main ────────────────────────────────────────────────────────
+main() {
+    show_banner
+    if [ "$ACTION" = "check" ]; then check_prereqs && _done "All prerequisites met!"; exit $?; fi
+    ensure_root
+    if [ "$ACTION" = "uninstall" ]; then do_uninstall; post_uninstall; exit 0; fi
+    check_prereqs || exit 1
+    locate_artifacts
+    do_install
+    post_install
+    verify
+}
+
+# Run main only when executed/piped directly (not when sourced by tests).
+script_source="${BASH_SOURCE[0]:-}"
+if [[ "$script_source" == "${0}" ]] || [[ -z "$script_source" ]]; then
+    main
+fi

--- a/shell/airdrop-autoheal/install.sh
+++ b/shell/airdrop-autoheal/install.sh
@@ -219,8 +219,11 @@ verify() {
     _step "Verifying with doctor…"; printf "\n"
     sleep 3   # let the daemon write its start line + spawn the log child
     if [ -x "$APPDIR/doctor.sh" ]; then
-        /bin/bash "$APPDIR/doctor.sh" || true
+        /bin/bash "$APPDIR/doctor.sh"   # exits with the number of FAILs (0 = healthy)
+        return $?
     fi
+    _warn "doctor.sh missing — skipping verification"
+    return 0
 }
 
 # ── Post-action boxes ───────────────────────────────────────────
@@ -250,8 +253,17 @@ main() {
     check_prereqs || exit 1
     locate_artifacts
     do_install
-    post_install
-    verify
+    # Gate the success box on doctor: a flapping daemon must NOT report success.
+    if verify; then
+        post_install
+    else
+        rc=$?
+        printf "\n"
+        _fail "doctor reported ${rc} problem(s) — the daemon did not come up healthy."
+        _info "Inspect: ${BOLD}sudo tail -50 ${LOGF}${RST}"
+        printf "\n"
+        exit "$rc"
+    fi
 }
 
 # Run main only when executed/piped directly (not when sourced by tests).

--- a/shell/airdrop-autoheal/selftest.sh
+++ b/shell/airdrop-autoheal/selftest.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Confirm the auto-heal works without a forgeable backdoor:
+#   1) daemon is loaded
+#   2) the detection predicate is valid AND matches real failures in the log
+#   3) the bounce ACTION works end-to-end via the root-only --bounce-once path
+# Uses sudo for the root-only action test (step 3).
+set -uo pipefail
+
+LABEL=com.indrasvat.airdrop-autoheal
+LOG=/var/log/airdrop-autoheal.log
+BIN="/Library/Application Support/airdrop-autoheal/airdrop-autoheal.sh"
+PRED='processImagePath == "/usr/libexec/sharingd" AND eventMessage CONTAINS "quic_migration_path_unavailable" AND eventMessage CONTAINS "awdl0"'
+
+echo "=== airdrop-autoheal self-test ==="
+
+# 1) loaded & running?
+if ! launchctl print "system/${LABEL}" >/dev/null 2>&1; then
+  echo "1) daemon: NOT loaded — run: sudo bash install.sh"
+  exit 1
+fi
+echo "1) daemon: loaded"
+launchctl print "system/${LABEL}" 2>/dev/null | awk '/state = |pid = /{gsub(/^[ \t]+/,""); print "     "$0}'
+
+# 2) predicate: valid syntax + how many real failures it caught recently
+echo "2) detection predicate vs. real logs (scanning last 12h — this takes a moment)…"
+if out=$(log show --last 12h --predicate "$PRED" --style compact 2>/dev/null); then
+  hits=$(printf '%s\n' "$out" | grep -c quic_migration_path_unavailable || true)
+  echo "     predicate VALID; matched ${hits} real awdl0-failure event(s) in last 12h"
+  echo "     (0 just means no failures happened recently — the predicate still parses & arms.)"
+else
+  echo "     predicate REJECTED by log(1) — syntax error, fix before trusting it"
+  exit 1
+fi
+
+# 3) action path: root-only one-shot bounce — the exact code the daemon runs
+echo "3) exercising the bounce action via 'sudo --bounce-once'…"
+before=$(/sbin/ifconfig awdl0 2>/dev/null | awk '/status:/{print $2}')
+sudo "$BIN" --bounce-once
+sleep 1
+after=$(/sbin/ifconfig awdl0 2>/dev/null | awk '/status:/{print $2}')
+if sudo tail -n 5 "$LOG" 2>/dev/null | grep -q "BOUNCED awdl0"; then
+  echo "     PASS — bounce executed + logged (awdl0 ${before:-?} -> ${after:-?})"
+else
+  echo "     FAIL — no BOUNCED line in audit log"
+  exit 1
+fi
+
+echo
+echo "RESULT: predicate validated against real logs + bounce action verified end-to-end."

--- a/shell/airdrop-autoheal/selftest.sh
+++ b/shell/airdrop-autoheal/selftest.sh
@@ -35,13 +35,20 @@ fi
 # 3) action path: root-only one-shot bounce — the exact code the daemon runs
 echo "3) exercising the bounce action via 'sudo --bounce-once'…"
 before=$(/sbin/ifconfig awdl0 2>/dev/null | awk '/status:/{print $2}')
-sudo "$BIN" --bounce-once
+# Count existing bounces FIRST so we require a NEW one — a stale BOUNCED line
+# from an earlier run must not falsely certify the reset path.
+bounces_before=$(sudo grep -c "BOUNCED awdl0" "$LOG" 2>/dev/null || true); bounces_before=${bounces_before:-0}
+if ! sudo "$BIN" --bounce-once; then
+  echo "     FAIL — '--bounce-once' returned non-zero"
+  exit 1
+fi
 sleep 1
 after=$(/sbin/ifconfig awdl0 2>/dev/null | awk '/status:/{print $2}')
-if sudo tail -n 5 "$LOG" 2>/dev/null | grep -q "BOUNCED awdl0"; then
-  echo "     PASS — bounce executed + logged (awdl0 ${before:-?} -> ${after:-?})"
+bounces_after=$(sudo grep -c "BOUNCED awdl0" "$LOG" 2>/dev/null || true); bounces_after=${bounces_after:-0}
+if [ "$bounces_after" -gt "$bounces_before" ]; then
+  echo "     PASS — a NEW bounce was logged (awdl0 ${before:-?} -> ${after:-?})"
 else
-  echo "     FAIL — no BOUNCED line in audit log"
+  echo "     FAIL — no new BOUNCED line (before=${bounces_before}, after=${bounces_after})"
   exit 1
 fi
 

--- a/shell/airdrop-autoheal/uninstall.sh
+++ b/shell/airdrop-autoheal/uninstall.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Convenience wrapper — uninstall the AirDrop auto-heal LaunchDaemon.
+# Delegates to install.sh (single source of truth). Auto-elevates with sudo.
+#   bash uninstall.sh        (or)   sudo bash uninstall.sh
+set -uo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+exec /bin/bash "$here/install.sh" --uninstall "$@"


### PR DESCRIPTION
Root LaunchDaemon that self-heals the macOS `awdl0` AirDrop path-migration flake — watches `sharingd` for `quic_migration_path_unavailable` on `awdl0` and re-primes the interface so the failed transfer's re-send succeeds.

- **Installer** (`shell/airdrop-autoheal/install.sh`): auto-elevates with sudo, runs from a clone or `curl | sudo bash`, idempotent load, verifies with `doctor`.
- **Hardened**: no orphaned subshells (FIFO + explicit-kill), PID-reuse guard, circuit breaker, never leaves `awdl0` down.
- Lint-clean (`make lint-shell`); `doctor` reports healthy on install.

Local install: `sudo bash shell/airdrop-autoheal/install.sh`
