### PR TITLE
fix(sarasa): harden noninteractive upgrades

### DIFF
--- a/go/sarasa/README.md
+++ b/go/sarasa/README.md
@@ -82,7 +82,15 @@ times = ["08:00", "14:00", "22:00"]
 
 Scheduled launchd runs use an explicit PATH that includes the directory
 containing the Sarasa binary, `~/.local/bin`, `~/bin`, `~/go/bin`, the current
-PATH at schedule install time, and the standard macOS system paths.
+PATH at schedule install time, and the standard macOS system paths. Sarasa also
+normalizes PATH for each child process, so custom tools installed into
+user-local directories continue to verify correctly even if an older launchd
+plist is still loaded.
+
+Homebrew cask upgrades that need access to app locations such as
+`/Applications`, sudo credentials, manual Caskroom cleanup, or explicit tap
+trust are deferred as skipped packages instead of being retried as noisy
+scheduled-run failures. Formula upgrades continue to run normally.
 
 ## Custom Tools
 
@@ -157,7 +165,7 @@ binary = "shux"
 missing = "install"
 current = { argv = ["shux", "--version"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
 latest = { github_release = "indrasvat/shux" }
-upgrade = { shell = "curl -sSfL https://raw.githubusercontent.com/indrasvat/shux/main/install.sh | sh -s -- --version ${latest} --dir ~/.local/bin", timeout = "15m" }
+upgrade = { shell = "curl -sSfL https://shux.pages.dev/install.sh | sh -s -- --version ${latest} --dir ~/.local/bin --no-skill", timeout = "15m" }
 verify = { argv = ["shux", "--version"], regex = "v?[0-9]+\\.[0-9]+\\.[0-9]+" }
 ```
 

--- a/go/sarasa/cmd/run.go
+++ b/go/sarasa/cmd/run.go
@@ -402,7 +402,7 @@ func runRunPlain(managers []manager.Manager, opts *manager.Options, cfg runTUI.M
 			}
 		}
 
-		if len(result.Skipped) > 0 && runDryRun {
+		if len(result.Skipped) > 0 {
 			hasOutput = true
 			for _, pkg := range result.Skipped {
 				majorTag := ""
@@ -413,14 +413,23 @@ func runRunPlain(managers []manager.Manager, opts *manager.Options, cfg runTUI.M
 				if pkg.Method != "" {
 					methodTag = " " + c(dim, "· "+pkg.Method)
 				}
-				fmt.Printf("    %s %s  %s %s %s%s%s\n",
+				reasonTag := ""
+				if pkg.SkipReason != "" {
+					reasonTag = " " + c(dim, "· "+pkg.SkipReason)
+				}
+				label := pkg.Latest
+				if !runDryRun {
+					label = "skipped"
+				}
+				fmt.Printf("    %s %s  %s %s %s%s%s%s\n",
 					c(brightMagenta, ui.IconTriangle),
 					c(bold+white, pkg.Name),
 					c(dim, pkg.Current),
 					c(dim, ui.IconArrow),
-					c(brightMagenta, pkg.Latest),
+					c(brightMagenta, label),
 					majorTag,
 					methodTag,
+					reasonTag,
 				)
 			}
 		}
@@ -472,7 +481,10 @@ func runRunPlain(managers []manager.Manager, opts *manager.Options, cfg runTUI.M
 		if totalFailed > 0 {
 			summaryParts = append(summaryParts, c(red, fmt.Sprintf("%d failed", totalFailed)))
 		}
-		if totalUpgraded == 0 && totalFailed == 0 {
+		if totalSkipped > 0 {
+			summaryParts = append(summaryParts, c(brightMagenta, fmt.Sprintf("%d skipped", totalSkipped)))
+		}
+		if totalUpgraded == 0 && totalFailed == 0 && totalSkipped == 0 {
 			summaryParts = append(summaryParts, c(green, "All up to date"))
 		}
 	}

--- a/go/sarasa/cmd/run_test.go
+++ b/go/sarasa/cmd/run_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/indrasvat/sarasa/internal/config"
@@ -119,6 +122,60 @@ func TestRunJSONReportsManagerFailures(t *testing.T) {
 	}
 	if len(got.Managers) != 1 || got.Managers[0].Error != "upgrade failed" {
 		t.Fatalf("missing manager error: %+v", got.Managers)
+	}
+}
+
+func TestRunPlainNonDryRunShowsSkippedSummary(t *testing.T) {
+	oldDryRun := runDryRun
+	oldSkipCleanup := runSkipCleanup
+	runDryRun = false
+	runSkipCleanup = true
+	t.Cleanup(func() {
+		runDryRun = oldDryRun
+		runSkipCleanup = oldSkipCleanup
+	})
+
+	mgr := &fakeRunManager{
+		name:      "brew",
+		available: true,
+		upgrade: &manager.UpgradeResult{
+			Skipped: []manager.Package{{
+				Name:       "demo-cask",
+				Current:    "1.0.0",
+				Latest:     "1.1.0",
+				Method:     "cask",
+				SkipReason: "requires manual cask app cleanup or admin lease",
+			}},
+		},
+	}
+	cfg := config.DefaultConfig()
+
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	oldStdout := os.Stdout
+	os.Stdout = writePipe
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	err = runRunPlain([]manager.Manager{mgr}, &manager.Options{Config: cfg}, &configWrapper{cfg: cfg}, false)
+	_ = writePipe.Close()
+	outputBytes, readErr := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatalf("runRunPlain failed: %v", err)
+	}
+	if readErr != nil {
+		t.Fatalf("read stdout: %v", readErr)
+	}
+
+	output := string(outputBytes)
+	for _, want := range []string{"demo-cask", "skipped", "requires manual cask app cleanup or admin lease", "1 skipped"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "All up to date") {
+		t.Fatalf("skipped-only run should not report all up to date:\n%s", output)
 	}
 }
 

--- a/go/sarasa/internal/manager/brew.go
+++ b/go/sarasa/internal/manager/brew.go
@@ -380,7 +380,7 @@ func (b *Brew) caskAppTargetDirs(ctx context.Context, name string) ([]string, er
 					targetDir = caskTargetDir(target)
 				}
 			}
-			if appRaw, ok := artifact["app"]; ok {
+			if appRaw, ok := artifact["app"]; ok && targetDir == brewAppDir {
 				if nestedTarget := nestedAppTarget(appRaw); nestedTarget != "" {
 					targetDir = caskTargetDir(nestedTarget)
 				}

--- a/go/sarasa/internal/manager/brew.go
+++ b/go/sarasa/internal/manager/brew.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/indrasvat/sarasa/internal/jsonutil"
@@ -152,6 +153,10 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 		log.Info("No outdated packages", "action", "upgrade")
 		return result, nil
 	}
+	brewPath, err := process.LookPath("brew")
+	if err != nil {
+		return nil, err
+	}
 
 	// Log outdated packages
 	names := make([]string, len(outdated))
@@ -172,7 +177,7 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 			result.Skipped = append(result.Skipped, pkg)
 			continue
 		}
-		if reason := b.deferReason(ctx, pkg); reason != "" {
+		if reason := b.deferReason(ctx, brewPath, pkg); reason != "" {
 			pkg.SkipReason = reason
 			logger.LogSkipped(b.Name(), pkg.Name, reason)
 			result.Skipped = append(result.Skipped, pkg)
@@ -182,10 +187,7 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 		start := time.Now()
 		args := append([]string{"upgrade"}, brewKindArg(pkg)...)
 		args = append(args, pkg.Name)
-		cmd := exec.CommandContext(ctx, "brew", args...)
-		if brewPath, err := process.LookPath("brew"); err == nil {
-			cmd = exec.CommandContext(ctx, brewPath, args...)
-		}
+		cmd := exec.CommandContext(ctx, brewPath, args...)
 		process.Configure(cmd, brewEnv())
 		output, err := cmd.CombinedOutput()
 		duration := time.Since(start).Milliseconds()
@@ -213,7 +215,7 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 		}
 
 		// Verify upgrade by checking installed version
-		newVersion, verifyErr := b.getInstalledVersion(ctx, pkg)
+		newVersion, verifyErr := b.getInstalledVersion(ctx, brewPath, pkg)
 		if verifyErr != nil {
 			log.Warn("Could not verify upgrade",
 				"package", pkg.Name,
@@ -242,11 +244,7 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 }
 
 // getInstalledVersion returns the currently installed version of a brew package.
-func (b *Brew) getInstalledVersion(ctx context.Context, pkg Package) (string, error) {
-	brewPath, err := process.LookPath("brew")
-	if err != nil {
-		return "", err
-	}
+func (b *Brew) getInstalledVersion(ctx context.Context, brewPath string, pkg Package) (string, error) {
 	args := append([]string{"info", "--json=v2"}, brewKindArg(pkg)...)
 	args = append(args, pkg.Name)
 	cmd := exec.CommandContext(ctx, brewPath, args...)
@@ -327,11 +325,11 @@ func brewEnv() map[string]string {
 	}
 }
 
-func (b *Brew) deferReason(ctx context.Context, pkg Package) string {
+func (b *Brew) deferReason(ctx context.Context, brewPath string, pkg Package) string {
 	if pkg.Method != brewMethodCask {
 		return ""
 	}
-	targetDirs, err := b.caskAppTargetDirs(ctx, pkg.Name)
+	targetDirs, err := b.caskAppTargetDirs(ctx, brewPath, pkg.Name)
 	if err != nil {
 		if !dirWritable(brewAppDir) {
 			return "cask app target requires admin/write access"
@@ -346,11 +344,7 @@ func (b *Brew) deferReason(ctx context.Context, pkg Package) string {
 	return ""
 }
 
-func (b *Brew) caskAppTargetDirs(ctx context.Context, name string) ([]string, error) {
-	brewPath, err := process.LookPath("brew")
-	if err != nil {
-		return nil, err
-	}
+func (b *Brew) caskAppTargetDirs(ctx context.Context, brewPath, name string) ([]string, error) {
 	cmd := exec.CommandContext(ctx, brewPath, "info", "--json=v2", "--cask", name)
 	process.Configure(cmd, brewEnv())
 	output, err := cmd.Output()
@@ -377,12 +371,20 @@ func (b *Brew) caskAppTargetDirs(ctx context.Context, name string) ([]string, er
 			if targetRaw, ok := artifact["target"]; ok {
 				var target string
 				if err := json.Unmarshal(targetRaw, &target); err == nil && target != "" {
-					targetDir = caskTargetDir(target)
+					if resolvedTargetDir, ok := caskTargetDir(target); ok {
+						targetDir = resolvedTargetDir
+					} else {
+						continue
+					}
 				}
 			}
 			if appRaw, ok := artifact["app"]; ok && targetDir == brewAppDir {
 				if nestedTarget := nestedAppTarget(appRaw); nestedTarget != "" {
-					targetDir = caskTargetDir(nestedTarget)
+					if resolvedTargetDir, ok := caskTargetDir(nestedTarget); ok {
+						targetDir = resolvedTargetDir
+					} else {
+						continue
+					}
 				}
 			}
 			targetDirs = append(targetDirs, targetDir)
@@ -422,14 +424,8 @@ func brewDeferredReason(pkg Package, output string) string {
 }
 
 func dirWritable(path string) bool {
-	file, err := os.CreateTemp(path, ".sarasa-write-test-*")
-	if err != nil {
-		return false
-	}
-	name := file.Name()
-	_ = file.Close()
-	_ = os.Remove(name)
-	return true
+	const writable = 2 // POSIX W_OK
+	return syscall.Access(path, writable) == nil
 }
 
 func expandHomePath(path string) string {
@@ -444,12 +440,51 @@ func expandHomePath(path string) string {
 	return path
 }
 
-func caskTargetDir(target string) string {
-	target = expandHomePath(target)
-	if filepath.IsAbs(target) {
-		return filepath.Dir(target)
+func expandBrewTargetPath(path string) (string, bool) {
+	path = expandHomePath(path)
+	replacements := map[string]string{
+		"$HOME":              homeDir(),
+		"${HOME}":            homeDir(),
+		"$APPDIR":            brewAppDir,
+		"${APPDIR}":          brewAppDir,
+		"$HOMEBREW_PREFIX":   homebrewPrefix(),
+		"${HOMEBREW_PREFIX}": homebrewPrefix(),
 	}
-	return brewAppDir
+	for token, value := range replacements {
+		if value != "" {
+			path = strings.ReplaceAll(path, token, value)
+		}
+	}
+	if strings.Contains(path, "$") {
+		return "", false
+	}
+	return path, true
+}
+
+func caskTargetDir(target string) (string, bool) {
+	target, ok := expandBrewTargetPath(target)
+	if !ok {
+		return "", false
+	}
+	if filepath.IsAbs(target) {
+		return filepath.Dir(target), true
+	}
+	return brewAppDir, true
+}
+
+func homeDir() string {
+	homeDir, _ := os.UserHomeDir()
+	return homeDir
+}
+
+func homebrewPrefix() string {
+	if prefix := strings.TrimSpace(os.Getenv("HOMEBREW_PREFIX")); prefix != "" {
+		return prefix
+	}
+	if _, err := os.Stat("/opt/homebrew"); err == nil {
+		return "/opt/homebrew"
+	}
+	return "/usr/local"
 }
 
 func nestedAppTarget(raw json.RawMessage) string {

--- a/go/sarasa/internal/manager/brew.go
+++ b/go/sarasa/internal/manager/brew.go
@@ -2,13 +2,17 @@ package manager
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/indrasvat/sarasa/internal/jsonutil"
 	"github.com/indrasvat/sarasa/internal/logger"
+	"github.com/indrasvat/sarasa/internal/process"
 )
 
 func init() {
@@ -19,6 +23,13 @@ func init() {
 type Brew struct {
 	opts *Options
 }
+
+const (
+	brewMethodFormula = "formula"
+	brewMethodCask    = "cask"
+)
+
+var brewAppDir = "/Applications"
 
 // NewBrew creates a new Homebrew manager.
 func NewBrew(opts *Options) Manager {
@@ -32,7 +43,7 @@ func (b *Brew) Name() string {
 }
 
 func (b *Brew) IsAvailable() bool {
-	_, err := exec.LookPath("brew")
+	_, err := process.LookPath("brew")
 	return err == nil
 }
 
@@ -60,8 +71,14 @@ type brewCask struct {
 }
 
 func (b *Brew) CheckOutdated(ctx context.Context) ([]Package, error) {
+	brewPath, err := process.LookPath("brew")
+	if err != nil {
+		return nil, err
+	}
+
 	// First run brew update
-	updateCmd := exec.CommandContext(ctx, "brew", "update")
+	updateCmd := exec.CommandContext(ctx, brewPath, "update")
+	process.Configure(updateCmd, brewEnv())
 	if err := updateCmd.Run(); err != nil {
 		return nil, fmt.Errorf("brew update failed: %w", err)
 	}
@@ -72,7 +89,8 @@ func (b *Brew) CheckOutdated(ctx context.Context) ([]Package, error) {
 		args = append(args, "--greedy")
 	}
 
-	cmd := exec.CommandContext(ctx, "brew", args...)
+	cmd := exec.CommandContext(ctx, brewPath, args...)
+	process.Configure(cmd, brewEnv())
 	output, err := cmd.Output()
 	if err != nil {
 		// brew outdated returns exit code 0 even with outdated packages
@@ -101,6 +119,7 @@ func (b *Brew) CheckOutdated(ctx context.Context) ([]Package, error) {
 			Name:    f.Name,
 			Current: f.InstalledVersions.First(),
 			Latest:  f.CurrentVersion,
+			Method:  brewMethodFormula,
 		})
 	}
 
@@ -113,6 +132,7 @@ func (b *Brew) CheckOutdated(ctx context.Context) ([]Package, error) {
 			Name:    c.Name,
 			Current: c.InstalledVersions.First(),
 			Latest:  c.CurrentVersion,
+			Method:  brewMethodCask,
 		})
 	}
 
@@ -152,13 +172,36 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 			result.Skipped = append(result.Skipped, pkg)
 			continue
 		}
+		if reason := b.deferReason(ctx, pkg); reason != "" {
+			pkg.SkipReason = reason
+			logger.LogSkipped(b.Name(), pkg.Name, reason)
+			result.Skipped = append(result.Skipped, pkg)
+			continue
+		}
 
 		start := time.Now()
-		cmd := exec.CommandContext(ctx, "brew", "upgrade", pkg.Name)
+		args := append([]string{"upgrade"}, brewKindArg(pkg)...)
+		args = append(args, pkg.Name)
+		cmd := exec.CommandContext(ctx, "brew", args...)
+		if brewPath, err := process.LookPath("brew"); err == nil {
+			cmd = exec.CommandContext(ctx, brewPath, args...)
+		}
+		process.Configure(cmd, brewEnv())
 		output, err := cmd.CombinedOutput()
 		duration := time.Since(start).Milliseconds()
 
 		if err != nil {
+			if reason := brewDeferredReason(pkg, string(output)); reason != "" {
+				log.Warn("brew upgrade deferred",
+					"package", pkg.Name,
+					"reason", reason,
+					"output", string(output),
+				)
+				pkg.SkipReason = reason
+				logger.LogSkipped(b.Name(), pkg.Name, reason)
+				result.Skipped = append(result.Skipped, pkg)
+				continue
+			}
 			log.Error("brew upgrade failed",
 				"package", pkg.Name,
 				"error", err.Error(),
@@ -170,7 +213,7 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 		}
 
 		// Verify upgrade by checking installed version
-		newVersion, verifyErr := b.getInstalledVersion(ctx, pkg.Name)
+		newVersion, verifyErr := b.getInstalledVersion(ctx, pkg)
 		if verifyErr != nil {
 			log.Warn("Could not verify upgrade",
 				"package", pkg.Name,
@@ -199,8 +242,15 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 }
 
 // getInstalledVersion returns the currently installed version of a brew package.
-func (b *Brew) getInstalledVersion(ctx context.Context, name string) (string, error) {
-	cmd := exec.CommandContext(ctx, "brew", "info", "--json=v2", name)
+func (b *Brew) getInstalledVersion(ctx context.Context, pkg Package) (string, error) {
+	brewPath, err := process.LookPath("brew")
+	if err != nil {
+		return "", err
+	}
+	args := append([]string{"info", "--json=v2"}, brewKindArg(pkg)...)
+	args = append(args, pkg.Name)
+	cmd := exec.CommandContext(ctx, brewPath, args...)
+	process.Configure(cmd, brewEnv())
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -238,20 +288,27 @@ func (b *Brew) Cleanup(ctx context.Context) error {
 	log := logger.WithManager(b.Name())
 
 	// Get current cache size before cleanup
-	duCmd := exec.CommandContext(ctx, "brew", "--cache")
+	brewPath, err := process.LookPath("brew")
+	if err != nil {
+		return err
+	}
+	duCmd := exec.CommandContext(ctx, brewPath, "--cache")
+	process.Configure(duCmd, brewEnv())
 	cacheDir, err := duCmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to get cache dir: %w", err)
 	}
 
 	// Run cleanup
-	cleanupCmd := exec.CommandContext(ctx, "brew", "cleanup")
+	cleanupCmd := exec.CommandContext(ctx, brewPath, "cleanup")
+	process.Configure(cleanupCmd, brewEnv())
 	if err := cleanupCmd.Run(); err != nil {
 		return fmt.Errorf("brew cleanup failed: %w", err)
 	}
 
 	// Run autoremove
-	autoremoveCmd := exec.CommandContext(ctx, "brew", "autoremove")
+	autoremoveCmd := exec.CommandContext(ctx, brewPath, "autoremove")
+	process.Configure(autoremoveCmd, brewEnv())
 	if err := autoremoveCmd.Run(); err != nil {
 		log.Warn("brew autoremove failed", "error", err.Error())
 	}
@@ -261,4 +318,153 @@ func (b *Brew) Cleanup(ctx context.Context) error {
 	_ = strings.TrimSpace(string(cacheDir))
 
 	return nil
+}
+
+func brewEnv() map[string]string {
+	return map[string]string{
+		"HOMEBREW_NO_ASK":       "1",
+		"HOMEBREW_NO_ENV_HINTS": "1",
+	}
+}
+
+func (b *Brew) deferReason(ctx context.Context, pkg Package) string {
+	if pkg.Method != brewMethodCask {
+		return ""
+	}
+	targetDirs, err := b.caskAppTargetDirs(ctx, pkg.Name)
+	if err != nil {
+		if !dirWritable(brewAppDir) {
+			return "cask app target requires admin/write access"
+		}
+		return ""
+	}
+	for _, targetDir := range targetDirs {
+		if !dirWritable(targetDir) {
+			return "cask app target requires admin/write access"
+		}
+	}
+	return ""
+}
+
+func (b *Brew) caskAppTargetDirs(ctx context.Context, name string) ([]string, error) {
+	brewPath, err := process.LookPath("brew")
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, brewPath, "info", "--json=v2", "--cask", name)
+	process.Configure(cmd, brewEnv())
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Casks []struct {
+			Artifacts []map[string]json.RawMessage `json:"artifacts"`
+		} `json:"casks"`
+	}
+	if err := jsonutil.Parse("brew", "info", output, &result); err != nil {
+		return nil, err
+	}
+
+	var targetDirs []string
+	for _, cask := range result.Casks {
+		for _, artifact := range cask.Artifacts {
+			if _, ok := artifact["app"]; !ok {
+				continue
+			}
+			targetDir := brewAppDir
+			if targetRaw, ok := artifact["target"]; ok {
+				var target string
+				if err := json.Unmarshal(targetRaw, &target); err == nil && target != "" {
+					targetDir = caskTargetDir(target)
+				}
+			}
+			if appRaw, ok := artifact["app"]; ok {
+				if nestedTarget := nestedAppTarget(appRaw); nestedTarget != "" {
+					targetDir = caskTargetDir(nestedTarget)
+				}
+			}
+			targetDirs = append(targetDirs, targetDir)
+		}
+	}
+	return targetDirs, nil
+}
+
+func brewKindArg(pkg Package) []string {
+	switch pkg.Method {
+	case brewMethodFormula:
+		return []string{"--formula"}
+	case brewMethodCask:
+		return []string{"--cask"}
+	default:
+		return nil
+	}
+}
+
+func brewDeferredReason(pkg Package, output string) string {
+	if pkg.Method != brewMethodCask {
+		return ""
+	}
+	text := strings.ToLower(output)
+	switch {
+	case strings.Contains(text, "sudo: a terminal is required") ||
+		strings.Contains(text, "sudo: a password is required") ||
+		strings.Contains(text, "which may request your password"):
+		return "requires sudo/admin credentials"
+	case strings.Contains(text, "there is already an app at"):
+		return "requires manual cask app cleanup or admin lease"
+	case strings.Contains(text, "refusing to load formula") && strings.Contains(text, "untrusted tap"):
+		return "requires explicit brew tap trust"
+	default:
+		return ""
+	}
+}
+
+func dirWritable(path string) bool {
+	file, err := os.CreateTemp(path, ".sarasa-write-test-*")
+	if err != nil {
+		return false
+	}
+	name := file.Name()
+	_ = file.Close()
+	_ = os.Remove(name)
+	return true
+}
+
+func expandHomePath(path string) string {
+	if path == "~" {
+		homeDir, _ := os.UserHomeDir()
+		return homeDir
+	}
+	if strings.HasPrefix(path, "~/") {
+		homeDir, _ := os.UserHomeDir()
+		return filepath.Join(homeDir, path[2:])
+	}
+	return path
+}
+
+func caskTargetDir(target string) string {
+	target = expandHomePath(target)
+	if filepath.IsAbs(target) {
+		return filepath.Dir(target)
+	}
+	return brewAppDir
+}
+
+func nestedAppTarget(raw json.RawMessage) string {
+	var values []json.RawMessage
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return ""
+	}
+	for _, value := range values {
+		var options map[string]string
+		if err := json.Unmarshal(value, &options); err != nil {
+			continue
+		}
+		if target := strings.TrimSpace(options["target"]); target != "" {
+			return target
+		}
+	}
+	return ""
 }

--- a/go/sarasa/internal/manager/brew_test.go
+++ b/go/sarasa/internal/manager/brew_test.go
@@ -79,6 +79,29 @@ JSON
 	}
 }
 
+func TestCaskAppTargetDirsPreservesResolvedTopLevelTarget(t *testing.T) {
+	userAppDir := t.TempDir()
+	brewDir := t.TempDir()
+	brewPath := filepath.Join(brewDir, "brew")
+	if err := os.WriteFile(brewPath, []byte(fmt.Sprintf(`#!/bin/sh
+cat <<'JSON'
+{"casks":[{"artifacts":[{"app":["Foo.app",{"target":"Bar.app"}],"target":%q}]}]}
+JSON
+`, filepath.Join(userAppDir, "Bar.app"))), 0755); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", brewDir)
+
+	b := NewBrew(&Options{}).(*Brew)
+	got, err := b.caskAppTargetDirs(context.Background(), "foo")
+	if err != nil {
+		t.Fatalf("caskAppTargetDirs failed: %v", err)
+	}
+	if len(got) != 1 || got[0] != userAppDir {
+		t.Fatalf("target dirs = %v, want [%s]", got, userAppDir)
+	}
+}
+
 func TestBrewKindArg(t *testing.T) {
 	tests := []struct {
 		name string

--- a/go/sarasa/internal/manager/brew_test.go
+++ b/go/sarasa/internal/manager/brew_test.go
@@ -1,0 +1,220 @@
+package manager
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestShouldDeferBrewCaskWhenAppDirIsNotWritable(t *testing.T) {
+	oldAppDir := brewAppDir
+	brewAppDir = t.TempDir() + "/missing"
+	t.Cleanup(func() { brewAppDir = oldAppDir })
+
+	brewDir := t.TempDir()
+	brewPath := filepath.Join(brewDir, "brew")
+	if err := os.WriteFile(brewPath, []byte(`#!/bin/sh
+cat <<'JSON'
+{"casks":[{"artifacts":[{"app":["Demo.app"]}]}]}
+JSON
+`), 0755); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", brewDir)
+
+	b := NewBrew(&Options{}).(*Brew)
+	if got := b.deferReason(context.Background(), Package{Name: "iterm2", Method: brewMethodCask}); got == "" {
+		t.Fatal("expected cask to be deferred when app dir is not writable")
+	}
+	if got := b.deferReason(context.Background(), Package{Name: "git", Method: brewMethodFormula}); got != "" {
+		t.Fatal("expected formula to remain upgradeable")
+	}
+}
+
+func TestShouldNotDeferCaskWithoutAppArtifacts(t *testing.T) {
+	brewDir := t.TempDir()
+	brewPath := filepath.Join(brewDir, "brew")
+	if err := os.WriteFile(brewPath, []byte(`#!/bin/sh
+cat <<'JSON'
+{"casks":[{"artifacts":[{"binary":["tool"],"target":"/opt/homebrew/bin/tool"}]}]}
+JSON
+`), 0755); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", brewDir)
+
+	b := NewBrew(&Options{}).(*Brew)
+	if got := b.deferReason(context.Background(), Package{Name: "tool-cask", Method: brewMethodCask}); got != "" {
+		t.Fatal("expected non-app cask to remain upgradeable")
+	}
+}
+
+func TestCaskAppTargetDirsParsesNestedTarget(t *testing.T) {
+	oldAppDir := brewAppDir
+	appDir := t.TempDir()
+	brewAppDir = appDir
+	t.Cleanup(func() { brewAppDir = oldAppDir })
+
+	brewDir := t.TempDir()
+	brewPath := filepath.Join(brewDir, "brew")
+	if err := os.WriteFile(brewPath, []byte(`#!/bin/sh
+cat <<'JSON'
+{"casks":[{"artifacts":[{"app":["Foo.app",{"target":"Bar.app"}]}]}]}
+JSON
+`), 0755); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", brewDir)
+
+	b := NewBrew(&Options{}).(*Brew)
+	got, err := b.caskAppTargetDirs(context.Background(), "foo")
+	if err != nil {
+		t.Fatalf("caskAppTargetDirs failed: %v", err)
+	}
+	if len(got) != 1 || got[0] != appDir {
+		t.Fatalf("target dirs = %v, want [%s]", got, appDir)
+	}
+}
+
+func TestBrewKindArg(t *testing.T) {
+	tests := []struct {
+		name string
+		pkg  Package
+		want string
+	}{
+		{"formula", Package{Method: brewMethodFormula}, "--formula"},
+		{"cask", Package{Method: brewMethodCask}, "--cask"},
+		{"unknown", Package{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := brewKindArg(tt.pkg)
+			if tt.want == "" {
+				if len(got) != 0 {
+					t.Fatalf("brewKindArg() = %v, want empty", got)
+				}
+				return
+			}
+			if len(got) != 1 || got[0] != tt.want {
+				t.Fatalf("brewKindArg() = %v, want [%s]", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrewDeferredReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "sudo password",
+			output: "sudo: a terminal is required to read the password\nsudo: a password is required",
+			want:   "requires sudo/admin credentials",
+		},
+		{
+			name:   "existing app",
+			output: "Error: zed: It seems there is already an App at '/opt/homebrew/Caskroom/zed/0.228.0/Zed.app'.",
+			want:   "requires manual cask app cleanup or admin lease",
+		},
+		{
+			name:   "untrusted tap",
+			output: "Error: Refusing to load formula cloudflare/cloudflare/warp from untrusted tap cloudflare/cloudflare.",
+			want:   "requires explicit brew tap trust",
+		},
+		{
+			name:   "ordinary error",
+			output: "Error: download failed",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := brewDeferredReason(Package{Method: brewMethodCask}, tt.output)
+			if got != tt.want {
+				t.Fatalf("brewDeferredReason() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBrewDeferredReasonDoesNotHideFormulaFailures(t *testing.T) {
+	output := "Error: Refusing to load formula cloudflare/cloudflare/warp from untrusted tap cloudflare/cloudflare."
+	if got := brewDeferredReason(Package{Method: brewMethodFormula}, output); got != "" {
+		t.Fatalf("formula failure deferred as %q", got)
+	}
+}
+
+func TestBrewUpgradeDefersCaskUpgradeFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	appDir := filepath.Join(tmpDir, "Applications")
+	if err := os.MkdirAll(appDir, 0755); err != nil {
+		t.Fatalf("create app dir: %v", err)
+	}
+	logPath := filepath.Join(tmpDir, "brew-args.log")
+	brewDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(brewDir, 0755); err != nil {
+		t.Fatalf("create brew dir: %v", err)
+	}
+	brewPath := filepath.Join(brewDir, "brew")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+case "$1" in
+  update)
+    exit 0
+    ;;
+  outdated)
+    cat <<'JSON'
+{"formulae":[],"casks":[{"name":"demo","installed_versions":["1.0.0"],"current_version":"1.1.0"}]}
+JSON
+    exit 0
+    ;;
+  info)
+    cat <<'JSON'
+{"casks":[{"installed":"1.0.0","artifacts":[{"app":["Demo.app"],"target":%q}]}]}
+JSON
+    exit 0
+    ;;
+  upgrade)
+    printf "Error: demo: It seems there is already an App at '/opt/homebrew/Caskroom/demo/1.0.0/Demo.app'.\n" >&2
+    exit 1
+    ;;
+esac
+exit 1
+`, logPath, filepath.Join(appDir, "Demo.app"))
+	if err := os.WriteFile(brewPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake brew: %v", err)
+	}
+	t.Setenv("PATH", brewDir)
+
+	result, err := NewBrew(&Options{}).Upgrade(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Upgrade failed: %v", err)
+	}
+	if len(result.Failed) != 0 {
+		t.Fatalf("expected no failures, got %+v", result.Failed)
+	}
+	if len(result.Skipped) != 1 {
+		t.Fatalf("expected 1 skipped package, got %+v", result.Skipped)
+	}
+	if result.Skipped[0].SkipReason != "requires manual cask app cleanup or admin lease" {
+		t.Fatalf("SkipReason = %q", result.Skipped[0].SkipReason)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read brew args log: %v", err)
+	}
+	logText := string(logBytes)
+	for _, want := range []string{"info --json=v2 --cask demo", "upgrade --cask demo"} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("brew args missing %q:\n%s", want, logText)
+		}
+	}
+}

--- a/go/sarasa/internal/manager/brew_test.go
+++ b/go/sarasa/internal/manager/brew_test.go
@@ -26,10 +26,10 @@ JSON
 	t.Setenv("PATH", brewDir)
 
 	b := NewBrew(&Options{}).(*Brew)
-	if got := b.deferReason(context.Background(), Package{Name: "iterm2", Method: brewMethodCask}); got == "" {
+	if got := b.deferReason(context.Background(), brewPath, Package{Name: "iterm2", Method: brewMethodCask}); got == "" {
 		t.Fatal("expected cask to be deferred when app dir is not writable")
 	}
-	if got := b.deferReason(context.Background(), Package{Name: "git", Method: brewMethodFormula}); got != "" {
+	if got := b.deferReason(context.Background(), brewPath, Package{Name: "git", Method: brewMethodFormula}); got != "" {
 		t.Fatal("expected formula to remain upgradeable")
 	}
 }
@@ -47,7 +47,7 @@ JSON
 	t.Setenv("PATH", brewDir)
 
 	b := NewBrew(&Options{}).(*Brew)
-	if got := b.deferReason(context.Background(), Package{Name: "tool-cask", Method: brewMethodCask}); got != "" {
+	if got := b.deferReason(context.Background(), brewPath, Package{Name: "tool-cask", Method: brewMethodCask}); got != "" {
 		t.Fatal("expected non-app cask to remain upgradeable")
 	}
 }
@@ -70,7 +70,7 @@ JSON
 	t.Setenv("PATH", brewDir)
 
 	b := NewBrew(&Options{}).(*Brew)
-	got, err := b.caskAppTargetDirs(context.Background(), "foo")
+	got, err := b.caskAppTargetDirs(context.Background(), brewPath, "foo")
 	if err != nil {
 		t.Fatalf("caskAppTargetDirs failed: %v", err)
 	}
@@ -93,12 +93,31 @@ JSON
 	t.Setenv("PATH", brewDir)
 
 	b := NewBrew(&Options{}).(*Brew)
-	got, err := b.caskAppTargetDirs(context.Background(), "foo")
+	got, err := b.caskAppTargetDirs(context.Background(), brewPath, "foo")
 	if err != nil {
 		t.Fatalf("caskAppTargetDirs failed: %v", err)
 	}
 	if len(got) != 1 || got[0] != userAppDir {
 		t.Fatalf("target dirs = %v, want [%s]", got, userAppDir)
+	}
+}
+
+func TestCaskTargetDirExpandsKnownTokens(t *testing.T) {
+	prefix := t.TempDir()
+	t.Setenv("HOMEBREW_PREFIX", prefix)
+
+	got, ok := caskTargetDir("$HOMEBREW_PREFIX/bin/fig")
+	if !ok {
+		t.Fatal("expected HOMEBREW_PREFIX target to resolve")
+	}
+	if got != filepath.Join(prefix, "bin") {
+		t.Fatalf("target dir = %q, want %q", got, filepath.Join(prefix, "bin"))
+	}
+}
+
+func TestCaskTargetDirRejectsUnknownTokens(t *testing.T) {
+	if got, ok := caskTargetDir("$UNKNOWN_APPDIR/Foo.app"); ok {
+		t.Fatalf("unknown token resolved to %q", got)
 	}
 }
 

--- a/go/sarasa/internal/manager/custom.go
+++ b/go/sarasa/internal/manager/custom.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/indrasvat/sarasa/internal/config"
 	"github.com/indrasvat/sarasa/internal/logger"
+	"github.com/indrasvat/sarasa/internal/process"
 )
 
 func init() {
@@ -286,7 +287,7 @@ func customToolAvailable(tool config.CustomToolConfig) bool {
 	if tool.Binary == "" {
 		return true
 	}
-	_, err := osexec.LookPath(tool.Binary)
+	_, err := process.LookPath(tool.Binary)
 	return err == nil
 }
 
@@ -415,10 +416,12 @@ func githubToken() string {
 }
 
 func latestGitHubReleaseWithGH(ctx context.Context, repo string) (string, error) {
-	if _, err := osexec.LookPath("gh"); err != nil {
+	ghPath, err := process.LookPath("gh")
+	if err != nil {
 		return "", err
 	}
-	cmd := osexec.CommandContext(ctx, "gh", "api", "repos/"+repo+"/releases/latest", "--jq", ".tag_name")
+	cmd := osexec.CommandContext(ctx, ghPath, "api", "repos/"+repo+"/releases/latest", "--jq", ".tag_name")
+	process.Configure(cmd, nil)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -479,15 +482,20 @@ func runCustomAction(ctx context.Context, defaultTimeout, toolTimeout string, ac
 		if len(argv) == 0 {
 			return "", errors.New("empty argv action")
 		}
-		cmd = osexec.CommandContext(cmdCtx, argv[0], argv[1:]...)
+		command := argv[0]
+		if path, err := process.LookPath(command); err == nil {
+			command = path
+		}
+		cmd = osexec.CommandContext(cmdCtx, command, argv[1:]...)
 	}
 	if action.Cwd != "" {
 		cmd.Dir = action.Cwd
 	}
-	cmd.Env = os.Environ()
+	extraEnv := make(map[string]string, len(action.Env))
 	for key, value := range action.Env {
-		cmd.Env = append(cmd.Env, key+"="+substitute(value, vars))
+		extraEnv[key] = substitute(value, vars)
 	}
+	process.Configure(cmd, extraEnv)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/go/sarasa/internal/manager/custom_test.go
+++ b/go/sarasa/internal/manager/custom_test.go
@@ -228,6 +228,46 @@ func TestCustomMissingPolicyInstallRunsAndVerifies(t *testing.T) {
 	}
 }
 
+func TestCustomMissingPolicyInstallVerifiesUserLocalBinaryFromSparsePath(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	toolPath := filepath.Join(binDir, "sarasa-path-tool")
+	installScript := "printf '#!/bin/sh\\necho v2.0.0\\n' > " + toolPath + " && chmod +x " + toolPath
+
+	cfg := config.DefaultConfig()
+	cfg.Custom.StateDir = filepath.Join(home, ".local", "state", "sarasa", "custom")
+	cfg.Custom.Tools = []config.CustomToolConfig{
+		{
+			Name:    "sarasa-path-tool",
+			Binary:  "sarasa-path-tool",
+			Missing: "install",
+			Latest:  config.CustomLatestConfig{Value: "v2.0.0"},
+			Upgrade: config.CustomActionConfig{Shell: installScript},
+			Verify: config.CustomProbeConfig{
+				Argv:  []string{"sarasa-path-tool", "--version"},
+				Regex: `v?[0-9]+\.[0-9]+\.[0-9]+`,
+			},
+		},
+	}
+
+	result, err := NewCustom(&Options{Config: cfg}).Upgrade(context.Background(), false)
+	if err != nil {
+		t.Fatalf("Upgrade failed: %v", err)
+	}
+	if len(result.Upgraded) != 1 {
+		t.Fatalf("expected 1 upgraded package, got %d failed=%d", len(result.Upgraded), len(result.Failed))
+	}
+	if result.Upgraded[0].Latest != "v2.0.0" {
+		t.Errorf("Latest = %q, want v2.0.0", result.Upgraded[0].Latest)
+	}
+}
+
 func TestCustomMissingPolicyFail(t *testing.T) {
 	cfg := config.DefaultConfig()
 	cfg.Custom.Tools = []config.CustomToolConfig{

--- a/go/sarasa/internal/manager/interface.go
+++ b/go/sarasa/internal/manager/interface.go
@@ -19,11 +19,12 @@ const (
 
 // Package represents a package that can be upgraded.
 type Package struct {
-	Name    string `json:"name"`
-	Current string `json:"current"`
-	Latest  string `json:"latest"`
-	IsMajor bool   `json:"is_major,omitempty"`
-	Method  string `json:"method,omitempty"`
+	Name       string `json:"name"`
+	Current    string `json:"current"`
+	Latest     string `json:"latest"`
+	IsMajor    bool   `json:"is_major,omitempty"`
+	Method     string `json:"method,omitempty"`
+	SkipReason string `json:"skip_reason,omitempty"`
 }
 
 // UpgradeResult holds the results of an upgrade operation.

--- a/go/sarasa/internal/manager/skills.go
+++ b/go/sarasa/internal/manager/skills.go
@@ -3,14 +3,18 @@ package manager
 import (
 	"bufio"
 	"context"
+	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/indrasvat/sarasa/internal/logger"
+	"github.com/indrasvat/sarasa/internal/process"
 )
 
 func init() {
@@ -22,6 +26,8 @@ type Skills struct {
 	opts *Options
 }
 
+var errSkillsReadOnlyCheckUnsupported = errors.New("skills CLI does not provide a read-only update check; run skills without dry-run to update")
+
 // NewSkills creates a new skills manager.
 func NewSkills(opts *Options) Manager {
 	return &Skills{opts: opts}
@@ -32,7 +38,7 @@ func (s *Skills) Name() string {
 }
 
 func (s *Skills) IsAvailable() bool {
-	if _, err := exec.LookPath("npx"); err != nil {
+	if _, err := process.LookPath("npx"); err != nil {
 		return false
 	}
 	_, err := os.Stat(skillLockFilePath())
@@ -40,89 +46,82 @@ func (s *Skills) IsAvailable() bool {
 }
 
 func (s *Skills) SetSkipList(packages []string) {
+	if s.opts == nil {
+		s.opts = &Options{}
+	}
 	s.opts.SkipList = packages
 }
 
 func (s *Skills) CheckOutdated(ctx context.Context) ([]Package, error) {
-	log := logger.WithManager(s.Name())
-
-	cmd := exec.CommandContext(ctx, "npx", "skills", "check")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		log.Debug("npx skills check returned non-zero",
-			"error", err.Error(),
-			"output", string(output),
-			"action", "check_outdated",
-		)
-		// npx skills check may exit non-zero but still produce useful output
-		if len(output) == 0 {
-			return nil, nil
-		}
-	}
-
-	if len(output) == 0 {
-		return nil, nil
-	}
-
-	packages, unparsed := parseSkillsCheckOutput(string(output))
-	if len(unparsed) > 0 {
-		log.Debug("Unparsed lines from npx skills check",
-			"unparsed_count", len(unparsed),
-		)
-	}
-
-	// Apply skip list filtering
-	var filtered []Package
-	for _, pkg := range packages {
-		if s.opts.ShouldSkip(pkg.Name) {
-			continue
-		}
-		filtered = append(filtered, pkg)
-	}
-
-	return filtered, nil
+	_ = ctx
+	return nil, errSkillsReadOnlyCheckUnsupported
 }
 
 func (s *Skills) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error) {
 	log := logger.WithManager(s.Name())
 	result := &UpgradeResult{}
 
-	// Pre-check outdated skills for reporting (honors skip list).
-	// Note: CheckOutdated may return (nil, nil) on transient failures,
-	// so we don't use this to gate the update — only for result reporting.
-	outdated, _ := s.CheckOutdated(ctx)
-
 	if dryRun {
-		result.Skipped = outdated
-		log.Info("Would run npx skills update", "action", "upgrade", "dry_run", true)
+		log.Info("Skipping skills dry-run because the skills CLI has no read-only check command",
+			"action", "upgrade",
+			"dry_run", true,
+		)
+		return result, errSkillsReadOnlyCheckUnsupported
+	}
+
+	targetSkills, skipped, err := s.updateTargets()
+	if err != nil {
+		return nil, err
+	}
+	result.Skipped = append(result.Skipped, skipped...)
+	if len(targetSkills) == 0 && len(skipped) > 0 {
+		log.Info("All tracked skills are in skip list", "action", "upgrade", "skipped", len(skipped))
 		return result, nil
 	}
 
-	logger.LogStart(s.Name())
-
+	args := skillsUpdateArgs(targetSkills)
+	cmd, commandLabel, err := s.command(ctx, args...)
+	if err != nil {
+		return nil, err
+	}
 	start := time.Now()
-	cmd := exec.CommandContext(ctx, "npx", "skills", "update")
 	output, err := cmd.CombinedOutput()
 	duration := time.Since(start).Milliseconds()
 
+	upgraded, failed, cliSkipped, unparsed := parseSkillsUpdateOutput(string(output))
+	result.Upgraded = append(result.Upgraded, upgraded...)
+	result.Failed = append(result.Failed, failed...)
+	result.Skipped = append(result.Skipped, cliSkipped...)
+	if len(unparsed) > 0 {
+		log.Debug("Unparsed lines from skills update",
+			"unparsed_count", len(unparsed),
+		)
+	}
+
 	if err != nil {
-		log.Error("npx skills update failed",
+		if len(result.Failed) == 0 {
+			result.Failed = append(result.Failed, Package{
+				Name:    "skills",
+				Current: customUnknown,
+				Latest:  "update failed",
+			})
+		}
+		log.Error("skills update failed",
 			"action", "upgrade",
+			"command", commandLabel,
 			"error", err.Error(),
 			"output", string(output),
 			"duration_ms", duration,
 		)
-		result.Failed = outdated
 		return result, err
 	}
 
-	// Populate result with pre-checked outdated packages so the
-	// TUI and plain renderers report what was upgraded.
-	result.Upgraded = outdated
-
-	log.Info("npx skills update completed",
+	log.Info("skills update completed",
 		"action", "complete",
+		"command", commandLabel,
 		"upgraded", len(result.Upgraded),
+		"failed", len(result.Failed),
+		"skipped", len(result.Skipped),
 		"duration_ms", duration,
 	)
 
@@ -131,6 +130,70 @@ func (s *Skills) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, erro
 
 func (s *Skills) Cleanup(_ context.Context) error {
 	return nil
+}
+
+func (s *Skills) command(ctx context.Context, args ...string) (*exec.Cmd, string, error) {
+	npxPath, err := process.LookPath("npx")
+	if err != nil {
+		return nil, "", err
+	}
+	cmdArgs := append([]string{"--yes", "skills"}, args...)
+	cmd := exec.CommandContext(ctx, npxPath, cmdArgs...)
+	process.Configure(cmd, nil)
+	return cmd, strings.Join(append([]string{npxPath}, cmdArgs...), " "), nil
+}
+
+func skillsUpdateArgs(skills []string) []string {
+	args := make([]string, 0, 3+len(skills))
+	args = append(args, "update", "--global", "--yes")
+	args = append(args, skills...)
+	return args
+}
+
+type skillLock struct {
+	Skills map[string]json.RawMessage `json:"skills"`
+}
+
+func readSkillLockNames() ([]string, error) {
+	data, err := os.ReadFile(skillLockFilePath())
+	if err != nil {
+		return nil, err
+	}
+	var lock skillLock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(lock.Skills))
+	for name := range lock.Skills {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (s *Skills) updateTargets() ([]string, []Package, error) {
+	if s.opts == nil || len(s.opts.SkipList) == 0 {
+		return nil, nil, nil
+	}
+	names, err := readSkillLockNames()
+	if err != nil {
+		return nil, nil, err
+	}
+	targets := make([]string, 0, len(names))
+	skipped := make([]Package, 0, len(s.opts.SkipList))
+	for _, name := range names {
+		if s.opts.ShouldSkip(name) {
+			skipped = append(skipped, Package{
+				Name:       name,
+				Current:    customUnknown,
+				Latest:     customUnknown,
+				SkipReason: "in skip list",
+			})
+			continue
+		}
+		targets = append(targets, name)
+	}
+	return targets, skipped, nil
 }
 
 // skillLockFilePath returns the path to the global skills lock file.
@@ -150,99 +213,126 @@ func stripANSI(s string) string {
 	return ansiPattern.ReplaceAllString(s, "")
 }
 
-// parseSkillsCheckOutput parses the output of `npx skills check`.
-//
-// Expected format:
-//
-//	Checking for skill updates...
-//	Checking N skill(s) for updates...
-//
-//	M update(s) available:
-//
-//	  ↑ skill-name
-//	    source: owner/repo
-//
-//	Run npx skills update to update all skills
-//
-//	Could not check N skill(s) (may need reinstall)
-//
-//	  ✗ skill-name
-//	    source: owner/repo
-func parseSkillsCheckOutput(output string) (packages []Package, unparsed []string) {
+func parseSkillsUpdateOutput(output string) (upgraded, failed, skipped []Package, unparsed []string) {
 	scanner := bufio.NewScanner(strings.NewReader(output))
-
-	// Track whether we're in the "updates available" section vs the "could not check" section
-	inUpdates := false
-	inErrors := false
-	var pendingName string
+	inSkipped := false
 
 	for scanner.Scan() {
 		line := stripANSI(scanner.Text())
 		trimmed := strings.TrimSpace(line)
-
-		// Skip empty lines
 		if trimmed == "" {
 			continue
 		}
 
-		// Detect section boundaries
-		if strings.Contains(trimmed, "update(s) available") {
-			inUpdates = true
-			inErrors = false
+		if strings.Contains(trimmed, "skill(s) cannot be checked automatically") {
+			inSkipped = true
 			continue
 		}
-		if strings.Contains(trimmed, "Could not check") {
-			inUpdates = false
-			inErrors = true
+		if strings.HasPrefix(trimmed, "To update:") {
 			continue
 		}
 
-		// Skip informational lines
-		if strings.HasPrefix(trimmed, "Checking") ||
-			strings.HasPrefix(trimmed, "Run npx skills") ||
-			strings.HasPrefix(trimmed, "All skills are up to date") {
-			continue
-		}
-
-		// Parse update entries: "↑ skill-name"
-		if inUpdates && strings.HasPrefix(trimmed, "↑") {
-			pendingName = strings.TrimSpace(strings.TrimPrefix(trimmed, "↑"))
-			continue
-		}
-
-		// Parse source line after an update entry
-		if inUpdates && pendingName != "" && strings.HasPrefix(trimmed, "source:") {
-			source := strings.TrimSpace(strings.TrimPrefix(trimmed, "source:"))
-			packages = append(packages, Package{
-				Name:    pendingName,
-				Current: source,
-				Latest:  "update available",
-				IsMajor: false,
+		if name, ok := parseUpdatedSkillLine(trimmed); ok {
+			upgraded = append(upgraded, Package{
+				Name:    name,
+				Current: customUnknown,
+				Latest:  "latest",
 			})
-			pendingName = ""
+			inSkipped = false
 			continue
 		}
-
-		// Skip error section entries (✗ lines and their sources)
-		if inErrors && (strings.HasPrefix(trimmed, "✗") || strings.HasPrefix(trimmed, "source:")) {
+		if name, ok := parseFailedSkillLine(trimmed); ok {
+			failed = append(failed, Package{
+				Name:    name,
+				Current: customUnknown,
+				Latest:  "update failed",
+			})
+			inSkipped = false
 			continue
 		}
-
-		// Track unparsed lines (excluding the ones we intentionally skip)
-		if inUpdates || inErrors {
-			unparsed = append(unparsed, trimmed)
+		if inSkipped {
+			parsed := parseSkippedSkillLine(trimmed)
+			if len(parsed) > 0 {
+				skipped = append(skipped, parsed...)
+				continue
+			}
 		}
+
+		if isSkillsUpdateInfoLine(trimmed) {
+			continue
+		}
+		unparsed = append(unparsed, trimmed)
 	}
 
-	// Handle case where an update entry had no source line
-	if pendingName != "" {
+	return upgraded, failed, skipped, unparsed
+}
+
+func parseUpdatedSkillLine(line string) (string, bool) {
+	if !strings.HasPrefix(line, "✓") {
+		return "", false
+	}
+	line = strings.TrimSpace(strings.TrimPrefix(line, "✓"))
+	if !strings.HasPrefix(line, "Updated") {
+		return "", false
+	}
+	line = strings.TrimSpace(strings.TrimPrefix(line, "Updated"))
+	if line == "" || strings.Contains(line, "skill(s)") {
+		return "", false
+	}
+	return strings.TrimSpace(line), true
+}
+
+func parseFailedSkillLine(line string) (string, bool) {
+	if !strings.HasPrefix(line, "✗") {
+		return "", false
+	}
+	line = strings.TrimSpace(strings.TrimPrefix(line, "✗"))
+	if !strings.HasPrefix(line, "Failed to update") {
+		return "", false
+	}
+	line = strings.TrimSpace(strings.TrimPrefix(line, "Failed to update"))
+	if line == "" || strings.Contains(line, "skill(s)") {
+		return "", false
+	}
+	return strings.TrimSpace(line), true
+}
+
+var skippedSkillPattern = regexp.MustCompile(`^•\s+(.+)\s+\(([^)]+)\)$`)
+
+func parseSkippedSkillLine(line string) []Package {
+	matches := skippedSkillPattern.FindStringSubmatch(line)
+	if len(matches) != 3 {
+		return nil
+	}
+	names := strings.Split(matches[1], ",")
+	packages := make([]Package, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
 		packages = append(packages, Package{
-			Name:    pendingName,
-			Current: customUnknown,
-			Latest:  "update available",
-			IsMajor: false,
+			Name:       name,
+			Current:    customUnknown,
+			Latest:     customUnknown,
+			SkipReason: matches[2],
 		})
 	}
+	return packages
+}
 
-	return packages, unparsed
+func isSkillsUpdateInfoLine(line string) bool {
+	return strings.HasPrefix(line, "Checking for skill updates") ||
+		strings.HasPrefix(line, "Checking skills from source:") ||
+		strings.HasPrefix(line, "Warning:") ||
+		strings.HasPrefix(line, "Skipping deletion in non-interactive mode") ||
+		strings.Contains(line, "GitHub rate limit reached") ||
+		strings.Contains(line, "set GITHUB_TOKEN") ||
+		strings.HasPrefix(line, "Found ") ||
+		strings.HasPrefix(line, "Updating ") ||
+		strings.HasPrefix(line, "•") ||
+		strings.HasPrefix(line, "✓ Updated ") ||
+		strings.HasPrefix(line, "Failed to update ") ||
+		strings.HasPrefix(line, "All global skills are up to date") ||
+		strings.HasPrefix(line, "✓ All global skills are up to date")
 }

--- a/go/sarasa/internal/manager/skills_test.go
+++ b/go/sarasa/internal/manager/skills_test.go
@@ -1,6 +1,8 @@
 package manager
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,172 +10,162 @@ import (
 
 const testSkillGhGhent = "gh-ghent"
 
-func TestParseSkillsCheckOutput_Empty(t *testing.T) {
-	packages, unparsed := parseSkillsCheckOutput("")
-	if len(packages) != 0 {
-		t.Errorf("expected 0 packages, got %d", len(packages))
+func TestSkillsCheckOutdatedUnsupported(t *testing.T) {
+	m := NewSkills(&Options{})
+
+	got, err := m.CheckOutdated(context.Background())
+	if !errors.Is(err, errSkillsReadOnlyCheckUnsupported) {
+		t.Fatalf("expected unsupported check error, got %v", err)
 	}
-	if len(unparsed) != 0 {
-		t.Errorf("expected 0 unparsed, got %d", len(unparsed))
+	if got != nil {
+		t.Fatalf("expected nil package list, got %v", got)
 	}
 }
 
-func TestParseSkillsCheckOutput_NoUpdates(t *testing.T) {
+func TestSkillsDryRunUnsupported(t *testing.T) {
+	m := NewSkills(&Options{})
+
+	got, err := m.Upgrade(context.Background(), true)
+	if !errors.Is(err, errSkillsReadOnlyCheckUnsupported) {
+		t.Fatalf("expected unsupported dry-run error, got %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(got.Upgraded) != 0 || len(got.Failed) != 0 || len(got.Skipped) != 0 {
+		t.Fatalf("expected empty result, got %+v", got)
+	}
+}
+
+func TestSkillsUpdateArgs_GlobalNonInteractive(t *testing.T) {
+	got := skillsUpdateArgs(nil)
+	expected := []string{"update", "--global", "--yes"}
+	assertStringSliceEqual(t, got, expected)
+}
+
+func TestSkillsUpdateArgs_WithSpecificSkills(t *testing.T) {
+	got := skillsUpdateArgs([]string{"cass", testSkillGhGhent})
+	expected := []string{"update", "--global", "--yes", "cass", testSkillGhGhent}
+	assertStringSliceEqual(t, got, expected)
+}
+
+func TestSkillsUpdateTargetsHonorsSkipList(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	lockPath := filepath.Join(home, ".agents", ".skill-lock.json")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	lock := `{
+  "version": 3,
+  "skills": {
+    "shux": {},
+    "cass": {},
+    "gh-ghent": {}
+  }
+}`
+	if err := os.WriteFile(lockPath, []byte(lock), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Skills{opts: &Options{SkipList: []string{"shux"}}}
+	targets, skipped, err := m.updateTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertStringSliceEqual(t, targets, []string{"cass", testSkillGhGhent})
+	if len(skipped) != 1 {
+		t.Fatalf("expected 1 skipped package, got %v", skipped)
+	}
+	if skipped[0].Name != "shux" || skipped[0].SkipReason != "in skip list" {
+		t.Fatalf("unexpected skipped package: %+v", skipped[0])
+	}
+}
+
+func TestParseSkillsUpdateOutput_NoUpdates(t *testing.T) {
 	output := `Checking for skill updates...
-Checking 5 skill(s) for updates...
 
-All skills are up to date`
+Checking skills from source: indrasvat/shux
+✓ All global skills are up to date`
 
-	packages, unparsed := parseSkillsCheckOutput(output)
-	if len(packages) != 0 {
-		t.Errorf("expected 0 packages, got %d", len(packages))
-	}
-	if len(unparsed) != 0 {
-		t.Errorf("expected 0 unparsed, got %d", len(unparsed))
+	upgraded, failed, skipped, unparsed := parseSkillsUpdateOutput(output)
+	if len(upgraded) != 0 || len(failed) != 0 || len(skipped) != 0 || len(unparsed) != 0 {
+		t.Fatalf("expected empty result, got upgraded=%v failed=%v skipped=%v unparsed=%v", upgraded, failed, skipped, unparsed)
 	}
 }
 
-func TestParseSkillsCheckOutput_SingleUpdate(t *testing.T) {
+func TestParseSkillsUpdateOutput_UpdatedAndFailed(t *testing.T) {
 	output := `Checking for skill updates...
-Checking 10 skill(s) for updates...
 
-1 update(s) available:
+Found 2 global update(s)
 
-  ↑ gh-ghent
-    source: indrasvat/gh-ghent
+Updating cass...
+  ✓ Updated cass
+Updating gh-ghent...
+  ✗ Failed to update gh-ghent
 
-Run npx skills update to update all skills`
+✓ Updated 1 skill(s)
+Failed to update 1 skill(s)`
 
-	packages, unparsed := parseSkillsCheckOutput(output)
-	if len(packages) != 1 {
-		t.Fatalf("expected 1 package, got %d", len(packages))
+	upgraded, failed, skipped, unparsed := parseSkillsUpdateOutput(output)
+	if len(upgraded) != 1 {
+		t.Fatalf("expected 1 upgraded package, got %v", upgraded)
 	}
-	if packages[0].Name != testSkillGhGhent {
-		t.Errorf("expected name=gh-ghent, got %s", packages[0].Name)
+	if upgraded[0].Name != "cass" {
+		t.Fatalf("expected cass upgraded, got %s", upgraded[0].Name)
 	}
-	if packages[0].Current != "indrasvat/gh-ghent" {
-		t.Errorf("expected current=indrasvat/gh-ghent, got %s", packages[0].Current)
+	if len(failed) != 1 {
+		t.Fatalf("expected 1 failed package, got %v", failed)
 	}
-	if packages[0].Latest != "update available" {
-		t.Errorf("expected latest='update available', got %s", packages[0].Latest)
+	if failed[0].Name != testSkillGhGhent {
+		t.Fatalf("expected gh-ghent failed, got %s", failed[0].Name)
 	}
-	if packages[0].IsMajor {
-		t.Error("expected IsMajor=false")
+	if len(skipped) != 0 {
+		t.Fatalf("expected 0 skipped packages, got %v", skipped)
 	}
 	if len(unparsed) != 0 {
-		t.Errorf("expected 0 unparsed, got %d: %v", len(unparsed), unparsed)
+		t.Fatalf("expected 0 unparsed lines, got %v", unparsed)
 	}
 }
 
-func TestParseSkillsCheckOutput_MultipleUpdates(t *testing.T) {
+func TestParseSkillsUpdateOutput_SkippedUncheckable(t *testing.T) {
 	output := `Checking for skill updates...
-Checking 21 skill(s) for updates...
 
-2 update(s) available:
+2 skill(s) cannot be checked automatically:
+  • local-one (Local path)
+  • legacy-one, legacy-two (No skill path recorded)
+    To update: npx skills add owner/repo -g -y`
 
-  ↑ cass
-    source: Dicklesworthstone/coding_agent_session_search
-  ↑ gh-ghent
-    source: indrasvat/gh-ghent
-
-Run npx skills update to update all skills`
-
-	packages, unparsed := parseSkillsCheckOutput(output)
-	if len(packages) != 2 {
-		t.Fatalf("expected 2 packages, got %d", len(packages))
+	upgraded, failed, skipped, unparsed := parseSkillsUpdateOutput(output)
+	if len(upgraded) != 0 || len(failed) != 0 {
+		t.Fatalf("expected no upgraded/failed packages, got upgraded=%v failed=%v", upgraded, failed)
 	}
-	if packages[0].Name != "cass" {
-		t.Errorf("expected first name=cass, got %s", packages[0].Name)
+	if len(skipped) != 3 {
+		t.Fatalf("expected 3 skipped packages, got %v", skipped)
 	}
-	if packages[0].Current != "Dicklesworthstone/coding_agent_session_search" {
-		t.Errorf("expected first source=Dicklesworthstone/coding_agent_session_search, got %s", packages[0].Current)
+	if skipped[0].Name != "local-one" || skipped[0].SkipReason != "Local path" {
+		t.Fatalf("unexpected first skipped package: %+v", skipped[0])
 	}
-	if packages[1].Name != testSkillGhGhent {
-		t.Errorf("expected second name=gh-ghent, got %s", packages[1].Name)
+	if skipped[1].Name != "legacy-one" || skipped[2].Name != "legacy-two" {
+		t.Fatalf("unexpected grouped skipped packages: %+v", skipped)
 	}
 	if len(unparsed) != 0 {
-		t.Errorf("expected 0 unparsed, got %d: %v", len(unparsed), unparsed)
+		t.Fatalf("expected 0 unparsed lines, got %v", unparsed)
 	}
 }
 
-func TestParseSkillsCheckOutput_WithErrorSection(t *testing.T) {
-	// Real-world output: updates + "could not check" entries
+func TestParseSkillsUpdateOutput_DeletedUpstreamWarning(t *testing.T) {
 	output := `Checking for skill updates...
-Checking 21 skill(s) for updates...
 
-2 update(s) available:
+Warning: The following skills from google-labs-code/stitch-skills appear to have been deleted upstream:
+  • react:components
+Skipping deletion in non-interactive mode.
+✓ All global skills are up to date`
 
-  ↑ cass
-    source: Dicklesworthstone/coding_agent_session_search
-  ↑ gh-ghent
-    source: indrasvat/gh-ghent
-
-Run npx skills update to update all skills
-
-Could not check 1 skill(s) (may need reinstall)
-
-  ✗ hugging-face-paper-pages
-    source: huggingface/skills`
-
-	packages, unparsed := parseSkillsCheckOutput(output)
-	if len(packages) != 2 {
-		t.Fatalf("expected 2 packages (errors excluded), got %d", len(packages))
-	}
-	if packages[0].Name != "cass" {
-		t.Errorf("expected first name=cass, got %s", packages[0].Name)
-	}
-	if packages[1].Name != testSkillGhGhent {
-		t.Errorf("expected second name=gh-ghent, got %s", packages[1].Name)
-	}
-	if len(unparsed) != 0 {
-		t.Errorf("expected 0 unparsed, got %d: %v", len(unparsed), unparsed)
-	}
-}
-
-func TestParseSkillsCheckOutput_WithANSICodes(t *testing.T) {
-	// Output with ANSI color codes wrapped around text
-	output := "\033[1mChecking for skill updates...\033[0m\n" +
-		"Checking 5 skill(s) for updates...\n\n" +
-		"\033[32m1 update(s) available:\033[0m\n\n" +
-		"  \033[33m↑\033[0m \033[1mmy-skill\033[0m\n" +
-		"    source: owner/repo\n\n" +
-		"Run npx skills update to update all skills"
-
-	packages, unparsed := parseSkillsCheckOutput(output)
-	if len(packages) != 1 {
-		t.Fatalf("expected 1 package, got %d", len(packages))
-	}
-	if packages[0].Name != "my-skill" {
-		t.Errorf("expected name=my-skill, got %s", packages[0].Name)
-	}
-	if packages[0].Current != "owner/repo" {
-		t.Errorf("expected current=owner/repo, got %s", packages[0].Current)
-	}
-	if len(unparsed) != 0 {
-		t.Errorf("expected 0 unparsed, got %d: %v", len(unparsed), unparsed)
-	}
-}
-
-func TestParseSkillsCheckOutput_UpdateWithoutSource(t *testing.T) {
-	// Edge case: update entry with no following source line
-	output := `Checking for skill updates...
-Checking 3 skill(s) for updates...
-
-1 update(s) available:
-
-  ↑ orphan-skill
-
-Run npx skills update to update all skills`
-
-	packages, _ := parseSkillsCheckOutput(output)
-	if len(packages) != 1 {
-		t.Fatalf("expected 1 package, got %d", len(packages))
-	}
-	if packages[0].Name != "orphan-skill" {
-		t.Errorf("expected name=orphan-skill, got %s", packages[0].Name)
-	}
-	if packages[0].Current != customUnknown {
-		t.Errorf("expected current=unknown for orphan, got %s", packages[0].Current)
+	upgraded, failed, skipped, unparsed := parseSkillsUpdateOutput(output)
+	if len(upgraded) != 0 || len(failed) != 0 || len(skipped) != 0 || len(unparsed) != 0 {
+		t.Fatalf("expected warning-only output to parse cleanly, got upgraded=%v failed=%v skipped=%v unparsed=%v", upgraded, failed, skipped, unparsed)
 	}
 }
 
@@ -214,5 +206,17 @@ func TestSkillLockFilePath_XDG(t *testing.T) {
 	expected := filepath.Join("/tmp/xdg-test", "skills", ".skill-lock.json")
 	if path != expected {
 		t.Errorf("expected %s, got %s", expected, path)
+	}
+}
+
+func assertStringSliceEqual(t *testing.T, got, expected []string) {
+	t.Helper()
+	if len(got) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, got)
+	}
+	for i := range expected {
+		if got[i] != expected[i] {
+			t.Fatalf("expected %v, got %v", expected, got)
+		}
 	}
 }

--- a/go/sarasa/internal/process/command.go
+++ b/go/sarasa/internal/process/command.go
@@ -1,20 +1,11 @@
 package process
 
-import (
-	"io"
-	"os/exec"
-)
+import "os/exec"
 
 // Configure prepares a child command for Sarasa's non-interactive execution
 // model.
 func Configure(cmd *exec.Cmd, extraEnv map[string]string) {
 	cmd.Env = Environment(extraEnv)
-	cmd.Stdin = io.NopCloser(&emptyReader{})
+	// A nil Stdin makes os/exec connect the child to the null device.
 	detachTTY(cmd)
-}
-
-type emptyReader struct{}
-
-func (r *emptyReader) Read(_ []byte) (int, error) {
-	return 0, io.EOF
 }

--- a/go/sarasa/internal/process/command.go
+++ b/go/sarasa/internal/process/command.go
@@ -1,0 +1,20 @@
+package process
+
+import (
+	"io"
+	"os/exec"
+)
+
+// Configure prepares a child command for Sarasa's non-interactive execution
+// model.
+func Configure(cmd *exec.Cmd, extraEnv map[string]string) {
+	cmd.Env = Environment(extraEnv)
+	cmd.Stdin = io.NopCloser(&emptyReader{})
+	detachTTY(cmd)
+}
+
+type emptyReader struct{}
+
+func (r *emptyReader) Read(_ []byte) (int, error) {
+	return 0, io.EOF
+}

--- a/go/sarasa/internal/process/command_unix.go
+++ b/go/sarasa/internal/process/command_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package process
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func detachTTY(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setsid = true
+}

--- a/go/sarasa/internal/process/command_windows.go
+++ b/go/sarasa/internal/process/command_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package process
+
+import "os/exec"
+
+func detachTTY(_ *exec.Cmd) {}

--- a/go/sarasa/internal/process/env.go
+++ b/go/sarasa/internal/process/env.go
@@ -1,0 +1,95 @@
+package process
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultPath returns a launchd-safe PATH for Sarasa child processes.
+//
+// Scheduled jobs do not inherit the user's interactive shell PATH. Custom
+// recipes often install tools into user-local directories, so every child
+// process gets those paths even when an older launchd plist is still loaded.
+func DefaultPath(binaryPath string) string {
+	homeDir, _ := os.UserHomeDir()
+	candidates := []string{}
+	if dir := filepath.Dir(binaryPath); binaryPath != "" && dir != "." {
+		candidates = append(candidates, dir)
+	}
+	if homeDir != "" {
+		candidates = append(candidates,
+			filepath.Join(homeDir, ".local", "bin"),
+			filepath.Join(homeDir, "bin"),
+			filepath.Join(homeDir, "go", "bin"),
+		)
+	}
+	candidates = append(candidates, filepath.SplitList(os.Getenv("PATH"))...)
+	candidates = append(candidates,
+		"/opt/homebrew/bin",
+		"/opt/homebrew/sbin",
+		"/usr/local/bin",
+		"/usr/bin",
+		"/bin",
+		"/usr/sbin",
+		"/sbin",
+	)
+
+	seen := make(map[string]bool, len(candidates))
+	path := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || !filepath.IsAbs(candidate) || seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+		path = append(path, candidate)
+	}
+	return strings.Join(path, string(os.PathListSeparator))
+}
+
+// Environment returns a normalized child-process environment.
+func Environment(extra map[string]string) []string {
+	env := make(map[string]string)
+	for _, item := range os.Environ() {
+		key, value, ok := strings.Cut(item, "=")
+		if !ok {
+			continue
+		}
+		env[key] = value
+	}
+	env["PATH"] = DefaultPath("")
+	env["HOMEBREW_NO_ASK"] = "1"
+	env["HOMEBREW_NO_ENV_HINTS"] = "1"
+	env["NONINTERACTIVE"] = "1"
+	env["SUDO_ASKPASS"] = "/usr/bin/false"
+	env["SSH_ASKPASS"] = "/usr/bin/false"
+	for key, value := range extra {
+		env[key] = value
+	}
+
+	out := make([]string, 0, len(env))
+	for key, value := range env {
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+// LookPath searches for a binary using Sarasa's normalized PATH.
+func LookPath(file string) (string, error) {
+	if path, err := exec.LookPath(file); err == nil {
+		return path, nil
+	}
+	if strings.ContainsRune(file, filepath.Separator) {
+		return exec.LookPath(file)
+	}
+
+	for _, dir := range filepath.SplitList(DefaultPath("")) {
+		path := filepath.Join(dir, file)
+		if info, err := os.Stat(path); err == nil && !info.IsDir() && info.Mode()&0111 != 0 {
+			return path, nil
+		}
+	}
+	return exec.LookPath(file)
+}

--- a/go/sarasa/internal/process/env_test.go
+++ b/go/sarasa/internal/process/env_test.go
@@ -1,0 +1,32 @@
+package process
+
+import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigureAddsUserLocalPathAndClosesStdin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	cmd := exec.Command("/bin/sh", "-c", "printf '%s' \"$PATH\"; read value || printf '\\nEOF'")
+	Configure(cmd, nil)
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, filepath.Join(home, ".local", "bin")) {
+		t.Fatalf("PATH missing user-local bin: %q", output)
+	}
+	if !strings.HasSuffix(output, "\nEOF") {
+		t.Fatalf("stdin was not closed: %q", output)
+	}
+}

--- a/go/sarasa/internal/scheduler/launchd.go
+++ b/go/sarasa/internal/scheduler/launchd.go
@@ -13,6 +13,7 @@ import (
 	"text/template"
 
 	"github.com/indrasvat/sarasa/internal/logger"
+	"github.com/indrasvat/sarasa/internal/process"
 )
 
 const (
@@ -156,39 +157,7 @@ func DefaultConfig() (*Config, error) {
 // tools are commonly installed in user-local directories, so include those
 // explicitly along with the directory containing the sarasa binary.
 func DefaultEnvironmentPath(binaryPath string) string {
-	homeDir, _ := os.UserHomeDir()
-	candidates := []string{}
-	if dir := filepath.Dir(binaryPath); binaryPath != "" && dir != "." {
-		candidates = append(candidates, dir)
-	}
-	if homeDir != "" {
-		candidates = append(candidates,
-			filepath.Join(homeDir, ".local", "bin"),
-			filepath.Join(homeDir, "bin"),
-			filepath.Join(homeDir, "go", "bin"),
-		)
-	}
-	candidates = append(candidates, filepath.SplitList(os.Getenv("PATH"))...)
-	candidates = append(candidates,
-		"/opt/homebrew/bin",
-		"/usr/local/bin",
-		"/usr/bin",
-		"/bin",
-		"/usr/sbin",
-		"/sbin",
-	)
-
-	seen := make(map[string]bool, len(candidates))
-	path := make([]string, 0, len(candidates))
-	for _, candidate := range candidates {
-		candidate = strings.TrimSpace(candidate)
-		if candidate == "" || !filepath.IsAbs(candidate) || seen[candidate] {
-			continue
-		}
-		seen[candidate] = true
-		path = append(path, candidate)
-	}
-	return strings.Join(path, ":")
+	return process.DefaultPath(binaryPath)
 }
 
 // GeneratePlist generates the launchd plist content.

--- a/go/sarasa/internal/tui/run/model.go
+++ b/go/sarasa/internal/tui/run/model.go
@@ -355,8 +355,12 @@ func (m Model) renderManagerPanel(result *ManagerResult, width int) string {
 				if pkg.Package.Method != "" {
 					methodTag = " " + ui.StyleMethodTag.Render("· "+pkg.Package.Method)
 				}
+				reasonTag := ""
+				if pkg.Package.SkipReason != "" {
+					reasonTag = " " + ui.StyleMethodTag.Render("· "+pkg.Package.SkipReason)
+				}
 
-				content.WriteString(fmt.Sprintf("  %s %s  %s %s %s%s%s", statusIcon, pkgName, current, arrow, latest, majorTag, methodTag))
+				content.WriteString(fmt.Sprintf("  %s %s  %s %s %s%s%s%s", statusIcon, pkgName, current, arrow, latest, majorTag, methodTag, reasonTag))
 				if i < len(result.Packages)-1 {
 					content.WriteString("\n")
 				}
@@ -393,7 +397,10 @@ func (m Model) renderSummary() string {
 		if m.totalFailed > 0 {
 			parts = append(parts, ui.StyleError.Render(fmt.Sprintf("%d failed", m.totalFailed)))
 		}
-		if m.totalUpgraded == 0 && m.totalFailed == 0 {
+		if m.totalSkipped > 0 {
+			parts = append(parts, lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#8B008B", Dark: "#DA70D6"}).Render(fmt.Sprintf("%d skipped", m.totalSkipped)))
+		}
+		if m.totalUpgraded == 0 && m.totalFailed == 0 && m.totalSkipped == 0 {
 			parts = append(parts, ui.StyleSuccess.Render("All up to date"))
 		}
 	}

--- a/go/sarasa/internal/tui/status/model.go
+++ b/go/sarasa/internal/tui/status/model.go
@@ -549,8 +549,12 @@ func (m Model) renderUpgradePanel(name string, result *upgradeResult, width int)
 				if pkg.Package.Method != "" {
 					methodTag = " " + ui.StyleMethodTag.Render("· "+pkg.Package.Method)
 				}
+				reasonTag := ""
+				if pkg.Package.SkipReason != "" {
+					reasonTag = " " + ui.StyleMethodTag.Render("· "+pkg.Package.SkipReason)
+				}
 
-				content.WriteString(fmt.Sprintf("  %s %s  %s %s %s%s%s", statusIcon, pkgName, current, arrow, latest, majorTag, methodTag))
+				content.WriteString(fmt.Sprintf("  %s %s  %s %s %s%s%s%s", statusIcon, pkgName, current, arrow, latest, majorTag, methodTag, reasonTag))
 				if i < len(result.Packages)-1 {
 					content.WriteString("\n")
 				}
@@ -607,7 +611,10 @@ func (m Model) renderUpgradeSummary() string {
 	if m.totalFailed > 0 {
 		parts = append(parts, ui.StyleError.Render(fmt.Sprintf("%d failed", m.totalFailed)))
 	}
-	if m.totalUpgraded == 0 && m.totalFailed == 0 {
+	if m.totalSkipped > 0 {
+		parts = append(parts, lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "#8B008B", Dark: "#DA70D6"}).Render(fmt.Sprintf("%d skipped", m.totalSkipped)))
+	}
+	if m.totalUpgraded == 0 && m.totalFailed == 0 && m.totalSkipped == 0 {
 		parts = append(parts, ui.StyleSuccess.Render("All up to date"))
 	}
 


### PR DESCRIPTION
## What
- Normalize Sarasa child-process PATH/stdin/TTY handling so scheduled custom tools installed in user-local dirs verify correctly and cannot surface interactive prompts in the TUI.
- Treat Homebrew app-cask/admin cleanup cases as explicit skipped/deferred results with JSON skip reasons, while keeping formula and non-app cask upgrades on the normal path.
- Run skills updates once as an explicit global, noninteractive command: `npx --yes skills update --global --yes`; stop using `npx skills check` because the upstream CLI routes it through the update path.

## Why
Hourly launchd runs were using sparse PATHs, so tools like `shux` and `dootsabha` could upgrade but fail verification. Brew app casks also repeatedly failed or could surface sudo/password prompts on work laptops without active admin leases. Skills had a separate correctness issue: dry-run/status could mutate skills via `skills check`, then the real run would report `0 upgraded`.

## Validation
- `go test ./...`
- Sparse PATH custom dry-run: `PATH=/usr/bin:/bin sarasa-test run --managers=custom --dry-run --json`
- Live brew deferral probe: `sarasa-test run --managers=brew --skip-cleanup --json` -> skipped casks, 0 failures
- Live skills dry-run/status: explicit unsupported read-only check error, no update command
- Live skills update: `sarasa-test run --managers=skills --skip-cleanup --json` -> success, 0 failures
- shux visual PNG captures for Sarasa dry-run and custom dry-run
