### PR TITLE
fix(sarasa): make brew token expansion deterministic

### DIFF
--- a/go/sarasa/internal/manager/brew.go
+++ b/go/sarasa/internal/manager/brew.go
@@ -442,17 +442,20 @@ func expandHomePath(path string) string {
 
 func expandBrewTargetPath(path string) (string, bool) {
 	path = expandHomePath(path)
-	replacements := map[string]string{
-		"$HOME":              homeDir(),
-		"${HOME}":            homeDir(),
-		"$APPDIR":            brewAppDir,
-		"${APPDIR}":          brewAppDir,
-		"$HOMEBREW_PREFIX":   homebrewPrefix(),
-		"${HOMEBREW_PREFIX}": homebrewPrefix(),
+	replacements := []struct {
+		token string
+		value string
+	}{
+		{"${HOMEBREW_PREFIX}", homebrewPrefix()},
+		{"$HOMEBREW_PREFIX", homebrewPrefix()},
+		{"${APPDIR}", brewAppDir},
+		{"$APPDIR", brewAppDir},
+		{"${HOME}", homeDir()},
+		{"$HOME", homeDir()},
 	}
-	for token, value := range replacements {
-		if value != "" {
-			path = strings.ReplaceAll(path, token, value)
+	for _, replacement := range replacements {
+		if replacement.value != "" {
+			path = strings.ReplaceAll(path, replacement.token, replacement.value)
 		}
 	}
 	if strings.Contains(path, "$") {

--- a/go/sarasa/internal/manager/brew_test.go
+++ b/go/sarasa/internal/manager/brew_test.go
@@ -104,14 +104,29 @@ JSON
 
 func TestCaskTargetDirExpandsKnownTokens(t *testing.T) {
 	prefix := t.TempDir()
+	home := t.TempDir()
 	t.Setenv("HOMEBREW_PREFIX", prefix)
+	t.Setenv("HOME", home)
 
-	got, ok := caskTargetDir("$HOMEBREW_PREFIX/bin/fig")
-	if !ok {
-		t.Fatal("expected HOMEBREW_PREFIX target to resolve")
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{"homebrew prefix", "$HOMEBREW_PREFIX/bin/fig", filepath.Join(prefix, "bin")},
+		{"braced homebrew prefix", "${HOMEBREW_PREFIX}/bin/fig", filepath.Join(prefix, "bin")},
+		{"home", "$HOME/Applications/Foo.app", filepath.Join(home, "Applications")},
 	}
-	if got != filepath.Join(prefix, "bin") {
-		t.Fatalf("target dir = %q, want %q", got, filepath.Join(prefix, "bin"))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := caskTargetDir(tt.target)
+			if !ok {
+				t.Fatal("expected target to resolve")
+			}
+			if got != tt.want {
+				t.Fatalf("target dir = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What
- Replace unordered brew target token expansion with deterministic ordered replacement.
- Cover overlapping `/opt/homebrew` / `/Users/robin.sharma` expansion in tests.

## Why
Main CI exposed nondeterministic Go map iteration: applying `/Users/robin.sharma` before `/opt/homebrew` corrupts paths like `/opt/homebrew/bin/fig` into `/home/runnerBREW_PREFIX/bin/fig`.

## Validation
- `go test ./internal/manager -run TestCaskTargetDirExpandsKnownTokens -count=100`
- `go test ./...`

Note: local `make ci` is currently blocked by existing lint findings from the locally installed Go lint toolchain, before test execution.