### PR TITLE
fix(sarasa): parallelize scheduled runs

### DIFF
--- a/go/sarasa/.golangci.yml
+++ b/go/sarasa/.golangci.yml
@@ -33,7 +33,6 @@ linters:
     - dupl
     - errorlint
     - exhaustive
-    - goconst
     - gocritic
     - gocyclo
     - misspell
@@ -62,10 +61,6 @@ linters-settings:
 
   dupl:
     threshold: 100
-
-  goconst:
-    min-len: 3
-    min-occurrences: 3
 
   misspell:
     locale: US

--- a/go/sarasa/.shux/fixtures/tui-run.toml
+++ b/go/sarasa/.shux/fixtures/tui-run.toml
@@ -1,0 +1,23 @@
+managers = ["brew", "volta", "pipx"]
+
+[skip]
+brew = ["skip-me"]
+volta = []
+pipx = []
+bun = []
+skills = []
+custom = []
+
+[logging]
+dir = ".shux/out/run-tui/logs"
+retention_days = 1
+level = "debug"
+
+[brew]
+greedy = false
+
+[npm]
+skip_major = false
+
+[volta]
+skip_major = false

--- a/go/sarasa/.shux/scripts/validate-run-tui-real-brew.sh
+++ b/go/sarasa/.shux/scripts/validate-run-tui-real-brew.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${ROOT}/.shux/out/run-tui-real-brew"
+BIN_DIR="${OUT_DIR}/bin"
+BINARY="${BIN_DIR}/sarasa-real"
+FAKE_BREW="${BIN_DIR}/brew"
+CONFIG="${OUT_DIR}/config.toml"
+STATE="${OUT_DIR}/brew-state.txt"
+LOG="${OUT_DIR}/brew-commands.log"
+SESSION="sarasa-run-tui-real-brew"
+
+mkdir -p "${BIN_DIR}"
+rm -rf "${OUT_DIR:?}/"*
+mkdir -p "${BIN_DIR}" "${OUT_DIR}/logs"
+
+cleanup() {
+    shux session kill "${SESSION}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+(cd "${ROOT}" && go build -o "${BINARY}" .)
+
+cat > "${CONFIG}" <<EOF_CONFIG
+managers = ["brew"]
+
+[skip]
+brew = []
+volta = []
+pipx = []
+bun = []
+skills = []
+custom = []
+
+[logging]
+dir = "${OUT_DIR}/logs"
+retention_days = 1
+level = "debug"
+
+[brew]
+greedy = false
+
+[npm]
+skip_major = false
+
+[volta]
+skip_major = false
+EOF_CONFIG
+
+cat > "${FAKE_BREW}" <<'EOF_BREW'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${SARASA_REAL_BREW_LOG}"
+
+version="1.0.0"
+if [[ -f "${SARASA_REAL_BREW_STATE}" ]]; then
+    version="$(cat "${SARASA_REAL_BREW_STATE}")"
+fi
+
+case "${1:-}" in
+    update)
+        exit 0
+        ;;
+    outdated)
+        cat <<JSON
+{"formulae":[{"name":"real-brew-demo","installed_versions":["${version}"],"current_version":"1.1.0"}],"casks":[]}
+JSON
+        exit 0
+        ;;
+    upgrade)
+        if [[ "${2:-}" == "--formula" && "${3:-}" == "real-brew-demo" ]]; then
+            printf '1.1.0' > "${SARASA_REAL_BREW_STATE}"
+            exit 0
+        fi
+        echo "unexpected brew upgrade args: $*" >&2
+        exit 2
+        ;;
+    info)
+        if [[ "${2:-}" == "--json=v2" && "${3:-}" == "--formula" && "${4:-}" == "real-brew-demo" ]]; then
+            cat <<JSON
+{"formulae":[{"name":"real-brew-demo","installed":[{"version":"${version}"}]}],"casks":[]}
+JSON
+            exit 0
+        fi
+        echo "unexpected brew info args: $*" >&2
+        exit 2
+        ;;
+    --cache)
+        printf '%s\n' "${TMPDIR:-/tmp}/sarasa-fake-brew-cache"
+        exit 0
+        ;;
+    cleanup|autoremove)
+        exit 0
+        ;;
+esac
+
+echo "unexpected brew args: $*" >&2
+exit 2
+EOF_BREW
+chmod +x "${FAKE_BREW}"
+
+cleanup
+shux --format json session create "${SESSION}" -d -- \
+    env -u NO_COLOR -u CI \
+        PATH="${BIN_DIR}:${PATH}" \
+        TERM=xterm-256color \
+        COLORTERM=truecolor \
+        SARASA_REAL_BREW_LOG="${LOG}" \
+        SARASA_REAL_BREW_STATE="${STATE}" \
+        "${BINARY}" --config "${CONFIG}" run --skip-cleanup >/dev/null
+
+shux pane set-size -s "${SESSION}" --cols 100 --rows 32 >/dev/null
+shux pane wait-for -s "${SESSION}" --text "real-brew-demo" --timeout-ms 15000 >/dev/null
+shux pane wait-for -s "${SESSION}" --text "1 upgraded" --timeout-ms 15000 >/dev/null
+shux pane wait-for -s "${SESSION}" --text "q quit" --timeout-ms 15000 >/dev/null
+
+shux pane capture -s "${SESSION}" > "${OUT_DIR}/capture.txt"
+shux --format json pane snapshot -s "${SESSION}" \
+    | jq -r .png_base64 \
+    | base64 -d > "${OUT_DIR}/snapshot.png"
+
+python3 - "${OUT_DIR}/capture.txt" "${OUT_DIR}/snapshot.png" "${STATE}" "${LOG}" <<'PY'
+import struct
+import sys
+from pathlib import Path
+
+capture = Path(sys.argv[1]).read_text()
+png = Path(sys.argv[2]).read_bytes()
+state = Path(sys.argv[3]).read_text()
+log = Path(sys.argv[4]).read_text()
+
+for text in ["SARASA UPGRADE", "BREW", "real-brew-demo", "1.0.0", "1.1.0", "1 upgraded", "q quit"]:
+    if text not in capture:
+        raise SystemExit(f"missing expected TUI text: {text!r}")
+
+if state != "1.1.0":
+    raise SystemExit(f"fake brew state = {state!r}, want '1.1.0'")
+
+for text in ["update", "outdated --json=v2", "upgrade --formula real-brew-demo", "info --json=v2 --formula real-brew-demo"]:
+    if text not in log:
+        raise SystemExit(f"missing expected brew command: {text!r}\n{log}")
+
+if png[:8] != b"\x89PNG\r\n\x1a\n":
+    raise SystemExit("snapshot is not a PNG")
+width, height = struct.unpack(">II", png[16:24])
+if width <= 0 or height <= 0:
+    raise SystemExit(f"invalid PNG dimensions: {width}x{height}")
+
+print(f"PASS shux real Brew TUI validation: png={width}x{height}, state={state}")
+PY

--- a/go/sarasa/.shux/scripts/validate-run-tui.sh
+++ b/go/sarasa/.shux/scripts/validate-run-tui.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${ROOT}/.shux/out/run-tui-final"
+BIN_DIR="${ROOT}/.shux/out/bin"
+BINARY="${BIN_DIR}/sarasa-fake"
+CONFIG="${ROOT}/.shux/fixtures/tui-run.toml"
+
+mkdir -p "${OUT_DIR}" "${BIN_DIR}"
+rm -rf "${OUT_DIR:?}/"*
+
+cleanup_session() {
+    local session="$1"
+    shux session kill "${session}" >/dev/null 2>&1 || true
+}
+
+(cd "${ROOT}" && go build -o "${BINARY}" ./internal/shuxtest/sarasa-fake)
+
+validate_viewport() {
+    local cols="$1"
+    local rows="$2"
+    local viewport="${cols}x${rows}"
+    local session="sarasa-run-tui-${viewport}"
+    local viewport_dir="${OUT_DIR}/${viewport}"
+    local events="${viewport_dir}/events.ndjson"
+
+    mkdir -p "${viewport_dir}"
+    rm -f "${events}"
+    cleanup_session "${session}"
+
+    shux --format json session create "${session}" -d -- \
+        env -u NO_COLOR -u CI \
+            TERM=xterm-256color \
+            COLORTERM=truecolor \
+            SARASA_SHUX_EXPECTED_MANAGERS=3 \
+            SARASA_SHUX_EVENTS="${events}" \
+            "${BINARY}" --config "${CONFIG}" run --skip-cleanup >/dev/null
+
+    trap 'cleanup_session "${session}"' RETURN
+
+    shux pane set-size -s "${session}" --cols "${cols}" --rows "${rows}" >/dev/null
+
+    shux pane wait-for -s "${session}" --text "BREW" --timeout-ms 10000 >/dev/null
+    shux pane wait-for -s "${session}" --text "VOLTA" --timeout-ms 10000 >/dev/null
+    shux pane wait-for -s "${session}" --text "PIPX" --timeout-ms 10000 >/dev/null
+    shux pane wait-for -s "${session}" --text "1 upgraded" --timeout-ms 10000 >/dev/null
+    shux pane wait-for -s "${session}" --text "1 failed" --timeout-ms 10000 >/dev/null
+    shux pane wait-for -s "${session}" --text "1 skipped" --timeout-ms 10000 >/dev/null
+    shux pane wait-for -s "${session}" --text "q quit" --timeout-ms 10000 >/dev/null
+
+    shux pane capture -s "${session}" > "${viewport_dir}/capture.txt"
+    shux --format json pane snapshot -s "${session}" \
+        | jq -r .png_base64 \
+        | base64 -d > "${viewport_dir}/snapshot.png"
+
+    python3 - "${viewport_dir}/capture.txt" "${viewport_dir}/snapshot.png" "${events}" "${viewport}" <<'PY'
+import json
+import struct
+import sys
+from pathlib import Path
+
+capture = Path(sys.argv[1]).read_text()
+png = Path(sys.argv[2]).read_bytes()
+events_path = Path(sys.argv[3])
+viewport = sys.argv[4]
+
+required = [
+    "BREW",
+    "VOLTA",
+    "PIPX",
+    "brew-upgraded",
+    "skip-me",
+    "volta-failed",
+    "1 upgraded",
+    "1 failed",
+    "1 skipped",
+    "q quit",
+]
+if viewport != "80x24":
+    required.append("SARASA UPGRADE")
+missing = [text for text in required if text not in capture]
+if missing:
+    raise SystemExit(f"missing expected TUI text: {missing}")
+
+for forbidden in ["waiting..."]:
+    if forbidden in capture:
+        raise SystemExit(f"unexpected non-final TUI text: {forbidden}")
+
+if png[:8] != b"\x89PNG\r\n\x1a\n":
+    raise SystemExit("snapshot is not a PNG")
+width, height = struct.unpack(">II", png[16:24])
+if width <= 0 or height <= 0:
+    raise SystemExit(f"invalid PNG dimensions: {width}x{height}")
+
+events = [json.loads(line) for line in events_path.read_text().splitlines() if line.strip()]
+starts = [event for event in events if event["event"] == "start"]
+dones = [event for event in events if event["event"] == "done"]
+if len(starts) != 3 or len(dones) != 3:
+    raise SystemExit(f"unexpected event counts: starts={len(starts)} dones={len(dones)}")
+first_done = next((i for i, event in enumerate(events) if event["event"] == "done"), None)
+last_start = max(i for i, event in enumerate(events) if event["event"] == "start")
+if first_done is None or first_done < last_start:
+    raise SystemExit(f"managers did not all start before first completion: {events}")
+
+print(f"PASS shux TUI validation {viewport}: png={width}x{height}, events={len(events)}")
+PY
+    cleanup_session "${session}"
+    trap - RETURN
+}
+
+validate_viewport 80 24
+validate_viewport 120 40

--- a/go/sarasa/README.md
+++ b/go/sarasa/README.md
@@ -92,6 +92,31 @@ Homebrew cask upgrades that need access to app locations such as
 trust are deferred as skipped packages instead of being retried as noisy
 scheduled-run failures. Formula upgrades continue to run normally.
 
+## Run Semantics
+
+`sarasa run` executes available managers concurrently in TUI, styled/plain, and
+JSON modes. Results are reported in the configured manager order, not completion
+order. Cleanup runs only after all upgrade phases finish, so a cleanup step
+cannot mutate package-manager state while another manager is still upgrading.
+
+Only one Sarasa run may execute at a time on a host. A non-blocking lock at
+`$XDG_CACHE_HOME/sarasa/run.lock`, or `~/Library/Caches/sarasa/run.lock` when
+`XDG_CACHE_HOME` is unset, causes overlapping launchd/manual runs to fail fast
+with `another sarasa run is already in progress`.
+
+Child commands run with a launchd-safe PATH and non-interactive environment.
+On Unix, timeout or cancellation signals the whole process group before killing
+it, so installer subprocesses are not left running after Sarasa exits.
+
+Homebrew uses scoped timeouts:
+
+| Operation | Timeout |
+| --- | ---: |
+| metadata (`outdated`, `info`, cache lookup) | 2m |
+| `brew update` | 10m |
+| `brew upgrade` per package | 30m |
+| `brew cleanup` / `autoremove` | 10m |
+
 ## Custom Tools
 
 Custom tools are recipes. Sarasa runs them through the same status, dry-run,
@@ -256,12 +281,22 @@ Local checks:
 ```bash
 make test
 make lint
+go test -race ./...
 ```
 
 Visual checks use shux so TUI rendering is verified in a real PTY:
 
 ```bash
+.shux/scripts/validate-run-tui.sh
+.shux/scripts/validate-run-tui-real-brew.sh
 .shux/scripts/capture-run-dry-run.sh
 .shux/scripts/capture-custom-dry-run.sh
 .shux/scripts/capture-run-json.sh
 ```
+
+`validate-run-tui.sh` builds a deterministic fake Sarasa binary, runs the real
+TUI through shux at `80x24` and `120x40`, captures PNG frames, and verifies that
+all fake managers start before any manager finishes.
+`validate-run-tui-real-brew.sh` runs the built Sarasa binary through the real
+Brew manager path against a fake `brew` executable, then verifies a controlled
+state-changing upgrade from `1.0.0` to `1.1.0`.

--- a/go/sarasa/cmd/root.go
+++ b/go/sarasa/cmd/root.go
@@ -118,7 +118,7 @@ func styledHelp(cmd *cobra.Command, args []string) {
 	// Header with icon
 	b.WriteString("\n")
 	if useColor {
-		b.WriteString(fmt.Sprintf("  %s %s\n", ui.IconDiamond, headerStyle.Render("SARASA")))
+		fmt.Fprintf(&b, "  %s %s\n", ui.IconDiamond, headerStyle.Render("SARASA"))
 	} else {
 		b.WriteString("  SARASA\n")
 	}
@@ -146,7 +146,7 @@ func styledHelp(cmd *cobra.Command, args []string) {
 		b.WriteString("  ")
 		for i, m := range managers {
 			style := lipgloss.NewStyle().Foreground(m.color)
-			b.WriteString(fmt.Sprintf("%s %s", m.icon, style.Render(m.name)))
+			fmt.Fprintf(&b, "%s %s", m.icon, style.Render(m.name))
 			if i < len(managers)-1 {
 				b.WriteString(mutedStyle.Render("  ·  "))
 			}
@@ -163,7 +163,7 @@ func styledHelp(cmd *cobra.Command, args []string) {
 	// Usage
 	b.WriteString(titleStyle.Render("  Usage:"))
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("    %s %s\n", cmdStyle.Render("sarasa"), mutedStyle.Render("[command]")))
+	fmt.Fprintf(&b, "    %s %s\n", cmdStyle.Render("sarasa"), mutedStyle.Render("[command]"))
 	b.WriteString("\n")
 
 	// Commands
@@ -184,7 +184,7 @@ func styledHelp(cmd *cobra.Command, args []string) {
 
 	for _, c := range commands {
 		cmdName := cmdStyle.Render(fmt.Sprintf("%-12s", c.name))
-		b.WriteString(fmt.Sprintf("    %s %s\n", cmdName, descStyle.Render(c.desc)))
+		fmt.Fprintf(&b, "    %s %s\n", cmdName, descStyle.Render(c.desc))
 	}
 	b.WriteString("\n")
 
@@ -203,7 +203,7 @@ func styledHelp(cmd *cobra.Command, args []string) {
 
 	for _, f := range flags {
 		flagName := flagStyle.Render(fmt.Sprintf("%-16s", f.flag))
-		b.WriteString(fmt.Sprintf("    %s %s\n", flagName, descStyle.Render(f.desc)))
+		fmt.Fprintf(&b, "    %s %s\n", flagName, descStyle.Render(f.desc))
 	}
 	b.WriteString("\n")
 
@@ -224,8 +224,8 @@ func styledHelp(cmd *cobra.Command, args []string) {
 	}
 
 	for _, e := range examples {
-		b.WriteString(fmt.Sprintf("    %s\n", cmdStyle.Render(e.cmd)))
-		b.WriteString(fmt.Sprintf("      %s\n", mutedStyle.Render(e.desc)))
+		fmt.Fprintf(&b, "    %s\n", cmdStyle.Render(e.cmd))
+		fmt.Fprintf(&b, "      %s\n", mutedStyle.Render(e.desc))
 	}
 	b.WriteString("\n")
 

--- a/go/sarasa/cmd/run.go
+++ b/go/sarasa/cmd/run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,6 +15,8 @@ import (
 
 	"github.com/indrasvat/sarasa/internal/logger"
 	"github.com/indrasvat/sarasa/internal/manager"
+	"github.com/indrasvat/sarasa/internal/runengine"
+	"github.com/indrasvat/sarasa/internal/runlock"
 	"github.com/indrasvat/sarasa/internal/signal"
 	runTUI "github.com/indrasvat/sarasa/internal/tui/run"
 	"github.com/indrasvat/sarasa/internal/ui"
@@ -85,6 +88,15 @@ type RunManagerResult struct {
 }
 
 func runRun(_ *cobra.Command, _ []string) error {
+	lock, err := runlock.Acquire()
+	if err != nil {
+		if errors.Is(err, runlock.ErrAlreadyRunning) {
+			return runlock.ErrAlreadyRunning
+		}
+		return fmt.Errorf("failed to acquire run lock: %w", err)
+	}
+	defer func() { _ = lock.Close() }()
+
 	cfg := GetConfig()
 	log := logger.Get()
 
@@ -140,7 +152,7 @@ func runRun(_ *cobra.Command, _ []string) error {
 	case ui.ModeTUI:
 		return runRunTUI(managers, opts, cfgWrapper)
 	case ui.ModeStyled, ui.ModePlain:
-		return runRunPlain(managers, opts, cfgWrapper, mode == ui.ModeStyled)
+		return runRunPlain(managers, cfgWrapper, mode == ui.ModeStyled)
 	}
 
 	return nil
@@ -153,73 +165,43 @@ func runRunJSON(managerNames []string, opts *manager.Options, cfg *configWrapper
 	output := RunOutput{
 		DryRun:   opts.DryRun,
 		Success:  true,
-		Managers: make([]RunManagerResult, 0, len(managerNames)),
+		Managers: make([]RunManagerResult, len(managerNames)),
 	}
-	overallStart := time.Now()
-
-	for _, name := range managerNames {
-		result := RunManagerResult{Name: name}
-
-		m, err := manager.Get(name, opts)
+	managers := make([]manager.Manager, 0, len(managerNames))
+	managerIndexes := make([]int, 0, len(managerNames))
+	for i, name := range managerNames {
+		m, err := manager.Get(name, opts.CloneWithSkipList(cfg.GetSkipList(name)))
 		if err != nil {
-			result.Error = err.Error()
+			result := RunManagerResult{Name: name, Error: err.Error()}
 			output.Success = false
 			output.Summary.ManagerErrors++
-			output.Managers = append(output.Managers, result)
+			output.Managers[i] = result
 			continue
 		}
-
-		result.Available = m.IsAvailable()
-		if !result.Available {
-			output.Managers = append(output.Managers, result)
+		if !m.IsAvailable() {
+			output.Managers[i] = RunManagerResult{Name: name, Available: false}
 			continue
 		}
-
-		opts.SkipList = cfg.GetSkipList(name)
-		logger.LogStart(m.Name())
-		start := time.Now()
-		upgradeResult, err := m.Upgrade(ctx, opts.DryRun)
-		result.DurationMs = time.Since(start).Milliseconds()
-		if err != nil {
-			result.Error = err.Error()
-			output.Success = false
-			output.Summary.ManagerErrors++
-			logger.LogComplete(m.Name(), 0, 1, result.DurationMs)
-			output.Managers = append(output.Managers, result)
-			continue
-		}
-		if upgradeResult == nil {
-			upgradeResult = &manager.UpgradeResult{}
-		}
-
-		result.Upgraded = upgradeResult.Upgraded
-		result.Failed = upgradeResult.Failed
-		if opts.DryRun {
-			result.WouldUpgrade = upgradeResult.Skipped
-			output.Summary.WouldUpgrade += len(upgradeResult.Skipped)
-		} else {
-			result.Skipped = upgradeResult.Skipped
-			output.Summary.Skipped += len(upgradeResult.Skipped)
-		}
-		output.Summary.Upgraded += len(upgradeResult.Upgraded)
-		output.Summary.Failed += len(upgradeResult.Failed)
-		if len(upgradeResult.Failed) > 0 {
-			output.Success = false
-		}
-
-		if !opts.DryRun && !opts.SkipCleanup {
-			if err := m.Cleanup(ctx); err != nil {
-				result.CleanupError = err.Error()
-				output.Success = false
-				output.Summary.ManagerErrors++
-			}
-		}
-
-		logger.LogComplete(m.Name(), len(upgradeResult.Upgraded), len(upgradeResult.Failed), result.DurationMs)
-		output.Managers = append(output.Managers, result)
+		managers = append(managers, m)
+		managerIndexes = append(managerIndexes, i)
 	}
 
-	output.DurationMs = time.Since(overallStart).Milliseconds()
+	runOutput := runengine.Runner{
+		DryRun:         opts.DryRun,
+		SkipCleanup:    opts.SkipCleanup,
+		ConfigProvider: cfg,
+	}.Run(ctx, managers)
+	output.DurationMs = runOutput.Duration.Milliseconds()
+	output.Success = output.Success && runOutput.Success
+	output.Summary.Upgraded += runOutput.Summary.Upgraded
+	output.Summary.Failed += runOutput.Summary.Failed
+	output.Summary.Skipped += runOutput.Summary.Skipped
+	output.Summary.WouldUpgrade += runOutput.Summary.WouldUpgrade
+	output.Summary.ManagerErrors += runOutput.Summary.ManagerErrors
+	for i, result := range toRunManagerResults(runOutput, opts.DryRun) {
+		output.Managers[managerIndexes[i]] = result
+	}
+
 	data, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
 		return err
@@ -269,11 +251,36 @@ func runRunTUI(managers []manager.Manager, opts *manager.Options, cfg runTUI.Man
 	return nil
 }
 
+func toRunManagerResults(output runengine.Output, dryRun bool) []RunManagerResult {
+	results := make([]RunManagerResult, 0, len(output.Managers))
+	for _, managerResult := range output.Managers {
+		result := RunManagerResult{
+			Name:       managerResult.Name,
+			Available:  managerResult.Available,
+			DurationMs: managerResult.Duration.Milliseconds(),
+			Upgraded:   managerResult.Upgraded,
+			Failed:     managerResult.Failed,
+		}
+		if dryRun {
+			result.WouldUpgrade = managerResult.Skipped
+		} else {
+			result.Skipped = managerResult.Skipped
+		}
+		if managerResult.Error != nil {
+			result.Error = managerResult.Error.Error()
+		}
+		if managerResult.CleanupError != nil {
+			result.CleanupError = managerResult.CleanupError.Error()
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
 //nolint:gocyclo // plain-text renderer with many formatting conditionals
-func runRunPlain(managers []manager.Manager, opts *manager.Options, cfg runTUI.ManagerConfigProvider, styled bool) error {
+func runRunPlain(managers []manager.Manager, cfg runTUI.ManagerConfigProvider, styled bool) error {
 	ctx, cancel := signal.NotifyContext(context.Background())
 	defer cancel()
-	log := logger.Get()
 
 	// Color helper
 	c := func(code, text string) string {
@@ -328,45 +335,24 @@ func runRunPlain(managers []manager.Manager, opts *manager.Options, cfg runTUI.M
 	fmt.Println(c(dim, "  ─────────────────────────────────────────"))
 	fmt.Println()
 
-	// Run upgrades for each manager
-	totalUpgraded := 0
-	totalFailed := 0
-	totalSkipped := 0
-	overallStart := time.Now()
+	runOutput := runengine.Runner{
+		DryRun:         runDryRun,
+		SkipCleanup:    runSkipCleanup,
+		ConfigProvider: cfg,
+	}.Run(ctx, managers)
 
-	for _, m := range managers {
-		// Check for cancellation
-		if ctx.Err() != nil {
-			fmt.Printf("\n  %s %s\n\n", c(yellow, ui.IconWarning), c(yellow, "Interrupted"))
-			break
-		}
-
-		// Set skip list for this manager
-		opts.SkipList = cfg.GetSkipList(m.Name())
-
-		mColor := managerColor(m.Name())
+	for _, result := range runOutput.Managers {
+		mColor := managerColor(result.Name)
 		icon := ""
 		if styled {
-			icon = ui.ManagerIcon(m.Name()) + " "
+			icon = ui.ManagerIcon(result.Name) + " "
 		}
 
 		// Manager header
-		fmt.Printf("  %s%s\n", icon, c(bold+mColor, strings.ToUpper(m.Name())))
+		fmt.Printf("  %s%s\n", icon, c(bold+mColor, strings.ToUpper(result.Name)))
 
-		logger.LogStart(m.Name())
-		start := time.Now()
-
-		// Run upgrade
-		result, err := m.Upgrade(ctx, runDryRun)
-		duration := time.Since(start)
-
-		if err != nil {
-			log.Error("Manager upgrade failed",
-				"manager", m.Name(),
-				"error", err.Error(),
-			)
-			fmt.Printf("    %s %s\n\n", c(red, ui.IconCross), c(red, err.Error()))
-			totalFailed++
+		if result.Error != nil {
+			fmt.Printf("    %s %s\n\n", c(red, ui.IconCross), c(red, result.Error.Error()))
 			continue
 		}
 
@@ -434,30 +420,22 @@ func runRunPlain(managers []manager.Manager, opts *manager.Options, cfg runTUI.M
 			}
 		}
 
+		if result.CleanupError != nil {
+			hasOutput = true
+			fmt.Printf("    %s %s\n",
+				c(yellow, ui.IconWarning),
+				c(yellow, "cleanup failed: "+result.CleanupError.Error()),
+			)
+		}
+
 		if !hasOutput {
 			fmt.Printf("    %s %s\n", c(green, ui.IconCheck), c(green, "Already up to date"))
 		}
 
-		totalUpgraded += len(result.Upgraded)
-		totalFailed += len(result.Failed)
-		totalSkipped += len(result.Skipped)
-
-		// Run cleanup
-		if !runDryRun && !runSkipCleanup {
-			if err := m.Cleanup(ctx); err != nil {
-				log.Warn("Cleanup failed",
-					"manager", m.Name(),
-					"error", err.Error(),
-				)
-			}
-		}
-
-		logger.LogComplete(m.Name(), len(result.Upgraded), len(result.Failed), duration.Milliseconds())
 		fmt.Println()
 	}
 
 	// Summary
-	overallDuration := time.Since(overallStart)
 	fmt.Println(c(dim, "  ─────────────────────────────────────────"))
 	fmt.Println()
 
@@ -465,42 +443,42 @@ func runRunPlain(managers []manager.Manager, opts *manager.Options, cfg runTUI.M
 	var summaryParts []string
 
 	if runDryRun {
-		if totalFailed > 0 {
-			summaryParts = append(summaryParts, c(red, fmt.Sprintf("%d failed", totalFailed)))
+		if runOutput.Summary.Failed > 0 {
+			summaryParts = append(summaryParts, c(red, fmt.Sprintf("%d failed", runOutput.Summary.Failed)))
 		}
-		if totalSkipped > 0 {
-			summaryParts = append(summaryParts, c(brightMagenta, fmt.Sprintf("%d to upgrade", totalSkipped)))
+		if runOutput.Summary.WouldUpgrade > 0 {
+			summaryParts = append(summaryParts, c(brightMagenta, fmt.Sprintf("%d to upgrade", runOutput.Summary.WouldUpgrade)))
 		}
-		if totalFailed == 0 && totalSkipped == 0 {
+		if runOutput.Summary.Failed == 0 && runOutput.Summary.WouldUpgrade == 0 {
 			summaryParts = append(summaryParts, c(green, "All up to date"))
 		}
 	} else {
-		if totalUpgraded > 0 {
-			summaryParts = append(summaryParts, c(green, fmt.Sprintf("%d upgraded", totalUpgraded)))
+		if runOutput.Summary.Upgraded > 0 {
+			summaryParts = append(summaryParts, c(green, fmt.Sprintf("%d upgraded", runOutput.Summary.Upgraded)))
 		}
-		if totalFailed > 0 {
-			summaryParts = append(summaryParts, c(red, fmt.Sprintf("%d failed", totalFailed)))
+		if runOutput.Summary.Failed > 0 || runOutput.Summary.ManagerErrors > 0 {
+			summaryParts = append(summaryParts, c(red, fmt.Sprintf("%d failed", runOutput.Summary.Failed+runOutput.Summary.ManagerErrors)))
 		}
-		if totalSkipped > 0 {
-			summaryParts = append(summaryParts, c(brightMagenta, fmt.Sprintf("%d skipped", totalSkipped)))
+		if runOutput.Summary.Skipped > 0 {
+			summaryParts = append(summaryParts, c(brightMagenta, fmt.Sprintf("%d skipped", runOutput.Summary.Skipped)))
 		}
-		if totalUpgraded == 0 && totalFailed == 0 && totalSkipped == 0 {
+		if runOutput.Summary.Upgraded == 0 && runOutput.Summary.Failed == 0 && runOutput.Summary.ManagerErrors == 0 && runOutput.Summary.Skipped == 0 {
 			summaryParts = append(summaryParts, c(green, "All up to date"))
 		}
 	}
 
 	// Duration
-	durationStr := formatDuration(overallDuration)
+	durationStr := formatDuration(runOutput.Duration)
 	summaryParts = append(summaryParts, c(dim, durationStr))
 
 	// Print summary
 	summaryIcon := ui.IconSparkle
-	if totalFailed > 0 {
+	if runOutput.Summary.Failed > 0 || runOutput.Summary.ManagerErrors > 0 {
 		summaryIcon = ui.IconFailed
 	}
 	fmt.Printf("  %s  %s\n", summaryIcon, strings.Join(summaryParts, c(dim, " · ")))
 
-	if runDryRun && totalSkipped > 0 {
+	if runDryRun && runOutput.Summary.WouldUpgrade > 0 {
 		fmt.Printf("     Run %s to apply upgrades\n", c(brightCyan+bold, "sarasa run"))
 	}
 

--- a/go/sarasa/cmd/run_test.go
+++ b/go/sarasa/cmd/run_test.go
@@ -8,19 +8,23 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/indrasvat/sarasa/internal/config"
 	"github.com/indrasvat/sarasa/internal/manager"
 )
 
 type fakeRunManager struct {
-	name       string
-	upgrade    *manager.UpgradeResult
-	upgradeErr error
-	cleanupErr error
-	available  bool
-	skipList   []string
+	name        string
+	upgrade     *manager.UpgradeResult
+	upgradeFunc func(context.Context, bool) (*manager.UpgradeResult, error)
+	upgradeErr  error
+	cleanupErr  error
+	available   bool
+	skipList    []string
+	mu          sync.Mutex
 }
 
 func (f *fakeRunManager) Name() string { return f.name }
@@ -31,7 +35,10 @@ func (f *fakeRunManager) CheckOutdated(context.Context) ([]manager.Package, erro
 	return nil, nil
 }
 
-func (f *fakeRunManager) Upgrade(context.Context, bool) (*manager.UpgradeResult, error) {
+func (f *fakeRunManager) Upgrade(ctx context.Context, dryRun bool) (*manager.UpgradeResult, error) {
+	if f.upgradeFunc != nil {
+		return f.upgradeFunc(ctx, dryRun)
+	}
 	if f.upgradeErr != nil {
 		return nil, f.upgradeErr
 	}
@@ -40,7 +47,11 @@ func (f *fakeRunManager) Upgrade(context.Context, bool) (*manager.UpgradeResult,
 
 func (f *fakeRunManager) Cleanup(context.Context) error { return f.cleanupErr }
 
-func (f *fakeRunManager) SetSkipList(packages []string) { f.skipList = packages }
+func (f *fakeRunManager) SetSkipList(packages []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.skipList = append([]string(nil), packages...)
+}
 
 func TestRunJSONDryRunUsesWouldUpgrade(t *testing.T) {
 	name := "test-run-json-dry"
@@ -125,6 +136,122 @@ func TestRunJSONReportsManagerFailures(t *testing.T) {
 	}
 }
 
+func TestRunJSONRunsManagersConcurrentlyWithStableOrder(t *testing.T) {
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+
+	first := "test-run-json-concurrent-first"
+	second := "test-run-json-concurrent-second"
+	manager.Register(first, func(*manager.Options) manager.Manager {
+		return &fakeRunManager{
+			name:      first,
+			available: true,
+			upgradeFunc: func(context.Context, bool) (*manager.UpgradeResult, error) {
+				close(firstStarted)
+				<-releaseFirst
+				return &manager.UpgradeResult{
+					Upgraded: []manager.Package{{Name: "first-pkg"}},
+				}, nil
+			},
+		}
+	})
+	manager.Register(second, func(*manager.Options) manager.Manager {
+		return &fakeRunManager{
+			name:      second,
+			available: true,
+			upgradeFunc: func(context.Context, bool) (*manager.UpgradeResult, error) {
+				select {
+				case <-firstStarted:
+				case <-time.After(time.Second):
+					t.Fatal("second manager did not overlap first manager")
+				}
+				close(releaseFirst)
+				return &manager.UpgradeResult{
+					Upgraded: []manager.Package{{Name: "second-pkg"}},
+				}, nil
+			},
+		}
+	})
+
+	cfg := config.DefaultConfig()
+	var out bytes.Buffer
+	err := runRunJSON(
+		[]string{first, second},
+		&manager.Options{Config: cfg},
+		&configWrapper{cfg: cfg},
+		&out,
+	)
+	if err != nil {
+		t.Fatalf("runRunJSON() error = %v", err)
+	}
+
+	var got RunOutput
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out.String())
+	}
+	if len(got.Managers) != 2 {
+		t.Fatalf("got %d managers, want 2", len(got.Managers))
+	}
+	if got.Managers[0].Name != first || got.Managers[1].Name != second {
+		t.Fatalf("manager order = [%s %s], want [%s %s]", got.Managers[0].Name, got.Managers[1].Name, first, second)
+	}
+}
+
+func TestRunJSONPreservesOrderWithUnavailableManager(t *testing.T) {
+	first := "test-run-json-order-first"
+	missing := "test-run-json-order-missing"
+	second := "test-run-json-order-second"
+	manager.Register(first, func(*manager.Options) manager.Manager {
+		return &fakeRunManager{
+			name:      first,
+			available: true,
+			upgrade: &manager.UpgradeResult{
+				Upgraded: []manager.Package{{Name: "first-pkg"}},
+			},
+		}
+	})
+	manager.Register(missing, func(*manager.Options) manager.Manager {
+		return &fakeRunManager{name: missing}
+	})
+	manager.Register(second, func(*manager.Options) manager.Manager {
+		return &fakeRunManager{
+			name:      second,
+			available: true,
+			upgrade: &manager.UpgradeResult{
+				Upgraded: []manager.Package{{Name: "second-pkg"}},
+			},
+		}
+	})
+
+	cfg := config.DefaultConfig()
+	var out bytes.Buffer
+	err := runRunJSON(
+		[]string{first, missing, second},
+		&manager.Options{Config: cfg},
+		&configWrapper{cfg: cfg},
+		&out,
+	)
+	if err != nil {
+		t.Fatalf("runRunJSON() error = %v", err)
+	}
+
+	var got RunOutput
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON output: %v\n%s", err, out.String())
+	}
+	if len(got.Managers) != 3 {
+		t.Fatalf("got %d managers, want 3", len(got.Managers))
+	}
+	for i, want := range []string{first, missing, second} {
+		if got.Managers[i].Name != want {
+			t.Fatalf("manager[%d] = %q, want %q; output=%+v", i, got.Managers[i].Name, want, got.Managers)
+		}
+	}
+	if got.Managers[1].Available {
+		t.Fatalf("middle manager should be unavailable: %+v", got.Managers[1])
+	}
+}
+
 func TestRunPlainNonDryRunShowsSkippedSummary(t *testing.T) {
 	oldDryRun := runDryRun
 	oldSkipCleanup := runSkipCleanup
@@ -158,7 +285,7 @@ func TestRunPlainNonDryRunShowsSkippedSummary(t *testing.T) {
 	os.Stdout = writePipe
 	t.Cleanup(func() { os.Stdout = oldStdout })
 
-	err = runRunPlain([]manager.Manager{mgr}, &manager.Options{Config: cfg}, &configWrapper{cfg: cfg}, false)
+	err = runRunPlain([]manager.Manager{mgr}, &configWrapper{cfg: cfg}, false)
 	_ = writePipe.Close()
 	outputBytes, readErr := io.ReadAll(readPipe)
 	if err != nil {
@@ -176,6 +303,75 @@ func TestRunPlainNonDryRunShowsSkippedSummary(t *testing.T) {
 	}
 	if strings.Contains(output, "All up to date") {
 		t.Fatalf("skipped-only run should not report all up to date:\n%s", output)
+	}
+}
+
+func TestRunPlainRunsManagersConcurrentlyWithStableOutputOrder(t *testing.T) {
+	oldDryRun := runDryRun
+	oldSkipCleanup := runSkipCleanup
+	runDryRun = false
+	runSkipCleanup = true
+	t.Cleanup(func() {
+		runDryRun = oldDryRun
+		runSkipCleanup = oldSkipCleanup
+	})
+
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	first := &fakeRunManager{
+		name:      "brew",
+		available: true,
+		upgradeFunc: func(context.Context, bool) (*manager.UpgradeResult, error) {
+			close(firstStarted)
+			<-releaseFirst
+			return &manager.UpgradeResult{
+				Upgraded: []manager.Package{{Name: "first-pkg", Current: "1.0.0", Latest: "1.1.0"}},
+			}, nil
+		},
+	}
+	second := &fakeRunManager{
+		name:      "custom",
+		available: true,
+		upgradeFunc: func(context.Context, bool) (*manager.UpgradeResult, error) {
+			select {
+			case <-firstStarted:
+			case <-time.After(time.Second):
+				t.Fatal("second manager did not overlap first manager")
+			}
+			close(releaseFirst)
+			return &manager.UpgradeResult{
+				Upgraded: []manager.Package{{Name: "second-pkg", Current: "1.0.0", Latest: "1.1.0"}},
+			}, nil
+		},
+	}
+
+	cfg := config.DefaultConfig()
+	readPipe, writePipe, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	oldStdout := os.Stdout
+	os.Stdout = writePipe
+	t.Cleanup(func() { os.Stdout = oldStdout })
+
+	err = runRunPlain([]manager.Manager{first, second}, &configWrapper{cfg: cfg}, false)
+	_ = writePipe.Close()
+	outputBytes, readErr := io.ReadAll(readPipe)
+	if err != nil {
+		t.Fatalf("runRunPlain failed: %v", err)
+	}
+	if readErr != nil {
+		t.Fatalf("read stdout: %v", readErr)
+	}
+
+	output := string(outputBytes)
+	firstIndex := strings.Index(output, "BREW")
+	secondIndex := strings.Index(output, "CUSTOM")
+	if firstIndex == -1 || secondIndex == -1 {
+		t.Fatalf("missing manager headers:\n%s", output)
+	}
+	if firstIndex > secondIndex {
+		t.Fatalf("plain output order is not input order:\n%s", output)
 	}
 }
 

--- a/go/sarasa/internal/exec/cancel_unix.go
+++ b/go/sarasa/internal/exec/cancel_unix.go
@@ -13,18 +13,31 @@ import (
 func configureCancel(cmd *exec.Cmd) func() {
 	done := make(chan struct{})
 	var doneOnce sync.Once
+	var mu sync.Mutex
+	var pgid int
+	var canceled bool
 	markDone := func() {
-		doneOnce.Do(func() {
-			close(done)
-		})
+		mu.Lock()
+		cancelWasSent := canceled
+		cancelPGID := pgid
+		mu.Unlock()
+		if !cancelWasSent || !processGroupExists(cancelPGID) {
+			doneOnce.Do(func() {
+				close(done)
+			})
+		}
 	}
 
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return os.ErrProcessDone
 		}
-		pgid := cmd.Process.Pid
-		if err := syscall.Kill(-pgid, syscall.SIGINT); err != nil && err != syscall.ESRCH {
+		cancelPGID := cmd.Process.Pid
+		mu.Lock()
+		pgid = cancelPGID
+		canceled = true
+		mu.Unlock()
+		if err := syscall.Kill(-cancelPGID, syscall.SIGINT); err != nil && err != syscall.ESRCH {
 			return err
 		}
 		go func() {
@@ -34,11 +47,21 @@ func configureCancel(cmd *exec.Cmd) func() {
 			case <-done:
 				return
 			case <-timer.C:
-				_ = syscall.Kill(-pgid, syscall.SIGKILL)
+				if processGroupExists(cancelPGID) {
+					_ = syscall.Kill(-cancelPGID, syscall.SIGKILL)
+				}
 			}
 		}()
 		return nil
 	}
 	cmd.WaitDelay = 5 * time.Second
 	return markDone
+}
+
+func processGroupExists(pgid int) bool {
+	if pgid <= 0 {
+		return false
+	}
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || err == syscall.EPERM
 }

--- a/go/sarasa/internal/exec/cancel_unix.go
+++ b/go/sarasa/internal/exec/cancel_unix.go
@@ -1,0 +1,44 @@
+//go:build !windows
+
+package exec
+
+import (
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+func configureCancel(cmd *exec.Cmd) func() {
+	done := make(chan struct{})
+	var doneOnce sync.Once
+	markDone := func() {
+		doneOnce.Do(func() {
+			close(done)
+		})
+	}
+
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		pgid := cmd.Process.Pid
+		if err := syscall.Kill(-pgid, syscall.SIGINT); err != nil && err != syscall.ESRCH {
+			return err
+		}
+		go func() {
+			timer := time.NewTimer(2 * time.Second)
+			defer timer.Stop()
+			select {
+			case <-done:
+				return
+			case <-timer.C:
+				_ = syscall.Kill(-pgid, syscall.SIGKILL)
+			}
+		}()
+		return nil
+	}
+	cmd.WaitDelay = 5 * time.Second
+	return markDone
+}

--- a/go/sarasa/internal/exec/cancel_windows.go
+++ b/go/sarasa/internal/exec/cancel_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package exec
+
+import "os/exec"
+
+func configureCancel(_ *exec.Cmd) func() {
+	return func() {}
+}

--- a/go/sarasa/internal/exec/exec.go
+++ b/go/sarasa/internal/exec/exec.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/indrasvat/sarasa/internal/process"
 	"github.com/indrasvat/sarasa/internal/retry"
 )
 
@@ -28,6 +29,7 @@ type Options struct {
 	Timeout     time.Duration // Command timeout (default: 5m)
 	Retry       bool          // Whether to retry on failure
 	RetryConfig retry.Config  // Retry configuration
+	Env         map[string]string
 }
 
 // DefaultOptions returns default execution options.
@@ -53,11 +55,14 @@ func Run(ctx context.Context, opts Options, name string, args ...string) (*Resul
 		defer cancel()
 
 		cmd := exec.CommandContext(cmdCtx, name, args...)
+		process.Configure(cmd, opts.Env)
+		markDone := configureCancel(cmd)
 		var stdout, stderr bytes.Buffer
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 
 		err := cmd.Run()
+		markDone()
 		result.Stdout = stdout.Bytes()
 		result.Stderr = stderr.Bytes()
 		result.Duration = time.Since(start)

--- a/go/sarasa/internal/exec/exec_test.go
+++ b/go/sarasa/internal/exec/exec_test.go
@@ -14,7 +14,7 @@ func TestRunTimeoutKillsProcessGroup(t *testing.T) {
 	marker := filepath.Join(dir, "child-finished")
 	script := filepath.Join(dir, "spawn-child.sh")
 	if err := os.WriteFile(script, []byte(`#!/bin/sh
-(sleep 2; touch "$1") &
+(sleep 10; touch "$1") &
 wait
 `), 0o755); err != nil {
 		t.Fatalf("write script: %v", err)

--- a/go/sarasa/internal/exec/exec_test.go
+++ b/go/sarasa/internal/exec/exec_test.go
@@ -1,0 +1,55 @@
+package exec
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRunTimeoutKillsProcessGroup(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "child-finished")
+	script := filepath.Join(dir, "spawn-child.sh")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+(sleep 2; touch "$1") &
+wait
+`), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	_, err := Run(context.Background(), Options{Timeout: 100 * time.Millisecond}, script, marker)
+	if err == nil {
+		t.Fatal("Run succeeded, want timeout")
+	}
+
+	time.Sleep(3 * time.Second)
+	if _, statErr := os.Stat(marker); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("grandchild survived timeout; marker stat err=%v", statErr)
+	}
+}
+
+func TestRunAppliesNonInteractiveEnvironment(t *testing.T) {
+	dir := t.TempDir()
+	output := filepath.Join(dir, "env.out")
+	script := filepath.Join(dir, "env.sh")
+	if err := os.WriteFile(script, []byte(`#!/bin/sh
+printf '%s\n' "$NONINTERACTIVE" "$SUDO_ASKPASS" > "$1"
+`), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	if _, err := Run(context.Background(), Options{Timeout: time.Second}, script, output); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+	got, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatalf("read env output: %v", err)
+	}
+	want := "1\n/usr/bin/false\n"
+	if string(got) != want {
+		t.Fatalf("env output = %q, want %q", string(got), want)
+	}
+}

--- a/go/sarasa/internal/manager/brew.go
+++ b/go/sarasa/internal/manager/brew.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
 
+	sarasaexec "github.com/indrasvat/sarasa/internal/exec"
 	"github.com/indrasvat/sarasa/internal/jsonutil"
 	"github.com/indrasvat/sarasa/internal/logger"
 	"github.com/indrasvat/sarasa/internal/process"
@@ -28,6 +28,11 @@ type Brew struct {
 const (
 	brewMethodFormula = "formula"
 	brewMethodCask    = "cask"
+
+	brewMetadataTimeout = 2 * time.Minute
+	brewUpdateTimeout   = 10 * time.Minute
+	brewUpgradeTimeout  = 30 * time.Minute
+	brewCleanupTimeout  = 10 * time.Minute
 )
 
 var brewAppDir = "/Applications"
@@ -77,10 +82,10 @@ func (b *Brew) CheckOutdated(ctx context.Context) ([]Package, error) {
 		return nil, err
 	}
 
-	// First run brew update
-	updateCmd := exec.CommandContext(ctx, brewPath, "update")
-	process.Configure(updateCmd, brewEnv())
-	if err := updateCmd.Run(); err != nil {
+	if _, err := sarasaexec.CombinedOutput(ctx, sarasaexec.Options{
+		Timeout: brewUpdateTimeout,
+		Env:     brewEnv(),
+	}, brewPath, "update"); err != nil {
 		return nil, fmt.Errorf("brew update failed: %w", err)
 	}
 
@@ -90,9 +95,10 @@ func (b *Brew) CheckOutdated(ctx context.Context) ([]Package, error) {
 		args = append(args, "--greedy")
 	}
 
-	cmd := exec.CommandContext(ctx, brewPath, args...)
-	process.Configure(cmd, brewEnv())
-	output, err := cmd.Output()
+	output, err := sarasaexec.Output(ctx, sarasaexec.Options{
+		Timeout: brewMetadataTimeout,
+		Env:     brewEnv(),
+	}, brewPath, args...)
 	if err != nil {
 		// brew outdated returns exit code 0 even with outdated packages
 		if len(output) == 0 {
@@ -187,9 +193,10 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 		start := time.Now()
 		args := append([]string{"upgrade"}, brewKindArg(pkg)...)
 		args = append(args, pkg.Name)
-		cmd := exec.CommandContext(ctx, brewPath, args...)
-		process.Configure(cmd, brewEnv())
-		output, err := cmd.CombinedOutput()
+		output, err := sarasaexec.CombinedOutput(ctx, sarasaexec.Options{
+			Timeout: brewUpgradeTimeout,
+			Env:     brewEnv(),
+		}, brewPath, args...)
 		duration := time.Since(start).Milliseconds()
 
 		if err != nil {
@@ -247,9 +254,10 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 func (b *Brew) getInstalledVersion(ctx context.Context, brewPath string, pkg Package) (string, error) {
 	args := append([]string{"info", "--json=v2"}, brewKindArg(pkg)...)
 	args = append(args, pkg.Name)
-	cmd := exec.CommandContext(ctx, brewPath, args...)
-	process.Configure(cmd, brewEnv())
-	output, err := cmd.Output()
+	output, err := sarasaexec.Output(ctx, sarasaexec.Options{
+		Timeout: brewMetadataTimeout,
+		Env:     brewEnv(),
+	}, brewPath, args...)
 	if err != nil {
 		return "", err
 	}
@@ -290,24 +298,27 @@ func (b *Brew) Cleanup(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	duCmd := exec.CommandContext(ctx, brewPath, "--cache")
-	process.Configure(duCmd, brewEnv())
-	cacheDir, err := duCmd.Output()
+	cacheDir, err := sarasaexec.Output(ctx, sarasaexec.Options{
+		Timeout: brewMetadataTimeout,
+		Env:     brewEnv(),
+	}, brewPath, "--cache")
 	if err != nil {
 		return fmt.Errorf("failed to get cache dir: %w", err)
 	}
 
 	// Run cleanup
-	cleanupCmd := exec.CommandContext(ctx, brewPath, "cleanup")
-	process.Configure(cleanupCmd, brewEnv())
-	if err := cleanupCmd.Run(); err != nil {
+	if _, err := sarasaexec.CombinedOutput(ctx, sarasaexec.Options{
+		Timeout: brewCleanupTimeout,
+		Env:     brewEnv(),
+	}, brewPath, "cleanup"); err != nil {
 		return fmt.Errorf("brew cleanup failed: %w", err)
 	}
 
 	// Run autoremove
-	autoremoveCmd := exec.CommandContext(ctx, brewPath, "autoremove")
-	process.Configure(autoremoveCmd, brewEnv())
-	if err := autoremoveCmd.Run(); err != nil {
+	if _, err := sarasaexec.CombinedOutput(ctx, sarasaexec.Options{
+		Timeout: brewCleanupTimeout,
+		Env:     brewEnv(),
+	}, brewPath, "autoremove"); err != nil {
 		log.Warn("brew autoremove failed", "error", err.Error())
 	}
 
@@ -345,9 +356,10 @@ func (b *Brew) deferReason(ctx context.Context, brewPath string, pkg Package) st
 }
 
 func (b *Brew) caskAppTargetDirs(ctx context.Context, brewPath, name string) ([]string, error) {
-	cmd := exec.CommandContext(ctx, brewPath, "info", "--json=v2", "--cask", name)
-	process.Configure(cmd, brewEnv())
-	output, err := cmd.Output()
+	output, err := sarasaexec.Output(ctx, sarasaexec.Options{
+		Timeout: brewMetadataTimeout,
+		Env:     brewEnv(),
+	}, brewPath, "info", "--json=v2", "--cask", name)
 	if err != nil {
 		return nil, err
 	}
@@ -414,6 +426,8 @@ func brewDeferredReason(pkg Package, output string) string {
 		strings.Contains(text, "sudo: a password is required") ||
 		strings.Contains(text, "which may request your password"):
 		return "requires sudo/admin credentials"
+	case strings.Contains(text, "command timed out after"):
+		return "requires manual cask upgrade after command timeout"
 	case strings.Contains(text, "there is already an app at"):
 		return "requires manual cask app cleanup or admin lease"
 	case strings.Contains(text, "refusing to load formula") && strings.Contains(text, "untrusted tap"):

--- a/go/sarasa/internal/manager/brew.go
+++ b/go/sarasa/internal/manager/brew.go
@@ -200,11 +200,12 @@ func (b *Brew) Upgrade(ctx context.Context, dryRun bool) (*UpgradeResult, error)
 		duration := time.Since(start).Milliseconds()
 
 		if err != nil {
-			if reason := brewDeferredReason(pkg, string(output)); reason != "" {
+			failureText := brewUpgradeFailureText(output, err)
+			if reason := brewDeferredReason(pkg, failureText); reason != "" {
 				log.Warn("brew upgrade deferred",
 					"package", pkg.Name,
 					"reason", reason,
-					"output", string(output),
+					"output", failureText,
 				)
 				pkg.SkipReason = reason
 				logger.LogSkipped(b.Name(), pkg.Name, reason)
@@ -435,6 +436,16 @@ func brewDeferredReason(pkg Package, output string) string {
 	default:
 		return ""
 	}
+}
+
+func brewUpgradeFailureText(output []byte, err error) string {
+	if err == nil {
+		return string(output)
+	}
+	if len(output) == 0 {
+		return err.Error()
+	}
+	return string(output) + "\n" + err.Error()
 }
 
 func dirWritable(path string) bool {

--- a/go/sarasa/internal/manager/brew_test.go
+++ b/go/sarasa/internal/manager/brew_test.go
@@ -213,6 +213,14 @@ func TestBrewDeferredReasonDoesNotHideFormulaFailures(t *testing.T) {
 	}
 }
 
+func TestBrewUpgradeFailureTextIncludesTimeoutError(t *testing.T) {
+	text := brewUpgradeFailureText(nil, fmt.Errorf("command timed out after 30m0s: signal: killed"))
+	got := brewDeferredReason(Package{Method: brewMethodCask}, text)
+	if got != "requires manual cask upgrade after command timeout" {
+		t.Fatalf("brewDeferredReason() = %q, want timeout deferral", got)
+	}
+}
+
 func TestBrewUpgradeDefersCaskUpgradeFailure(t *testing.T) {
 	tmpDir := t.TempDir()
 	appDir := filepath.Join(tmpDir, "Applications")

--- a/go/sarasa/internal/manager/brew_test.go
+++ b/go/sarasa/internal/manager/brew_test.go
@@ -180,6 +180,11 @@ func TestBrewDeferredReason(t *testing.T) {
 			want:   "requires manual cask app cleanup or admin lease",
 		},
 		{
+			name:   "timeout",
+			output: "command timed out after 30m0s: signal: killed",
+			want:   "requires manual cask upgrade after command timeout",
+		},
+		{
 			name:   "untrusted tap",
 			output: "Error: Refusing to load formula cloudflare/cloudflare/warp from untrusted tap cloudflare/cloudflare.",
 			want:   "requires explicit brew tap trust",

--- a/go/sarasa/internal/manager/interface.go
+++ b/go/sarasa/internal/manager/interface.go
@@ -66,6 +66,29 @@ type Options struct {
 	Config      *config.Config
 }
 
+// Clone returns an independent copy of Options for one manager instance.
+func (o *Options) Clone() *Options {
+	if o == nil {
+		return &Options{}
+	}
+	clone := *o
+	if o.SkipList != nil {
+		clone.SkipList = append([]string(nil), o.SkipList...)
+	}
+	return &clone
+}
+
+// CloneWithSkipList returns an independent copy with a manager-specific skip list.
+func (o *Options) CloneWithSkipList(packages []string) *Options {
+	clone := o.Clone()
+	if packages != nil {
+		clone.SkipList = append([]string(nil), packages...)
+	} else {
+		clone.SkipList = nil
+	}
+	return clone
+}
+
 // ShouldSkip checks if a package should be skipped.
 func (o *Options) ShouldSkip(pkg string) bool {
 	for _, s := range o.SkipList {

--- a/go/sarasa/internal/manager/options_test.go
+++ b/go/sarasa/internal/manager/options_test.go
@@ -1,6 +1,8 @@
 package manager_test
 
 import (
+	"context"
+	"slices"
 	"testing"
 
 	"github.com/indrasvat/sarasa/internal/manager"
@@ -52,3 +54,67 @@ func TestOptions_ShouldSkip_NilList(t *testing.T) {
 		t.Error("ShouldSkip should return false with nil list")
 	}
 }
+
+func TestGetMultipleClonesOptionsPerManager(t *testing.T) {
+	nameA := "test-options-clone-a"
+	nameB := "test-options-clone-b"
+
+	manager.Register(nameA, func(opts *manager.Options) manager.Manager {
+		return &optionInspectManager{name: nameA, opts: opts}
+	})
+	manager.Register(nameB, func(opts *manager.Options) manager.Manager {
+		return &optionInspectManager{name: nameB, opts: opts}
+	})
+
+	managers, err := manager.GetMultiple([]string{nameA, nameB}, &manager.Options{
+		SkipList: []string{"base"},
+	})
+	if err != nil {
+		t.Fatalf("GetMultiple failed: %v", err)
+	}
+	if len(managers) != 2 {
+		t.Fatalf("got %d managers, want 2", len(managers))
+	}
+
+	first := managers[0].(*optionInspectManager)
+	second := managers[1].(*optionInspectManager)
+	if first.opts == second.opts {
+		t.Fatal("managers share the same *Options pointer")
+	}
+
+	first.SetSkipList([]string{"first-only"})
+	if second.opts.ShouldSkip("first-only") {
+		t.Fatal("SetSkipList on first manager leaked into second manager")
+	}
+	if !second.opts.ShouldSkip("base") {
+		t.Fatal("cloned options did not preserve original skip list")
+	}
+}
+
+func TestManagerListOrderIsDeterministic(t *testing.T) {
+	names := manager.List()
+	if !slices.IsSorted(names) {
+		t.Fatalf("manager.List() is not sorted: %v", names)
+	}
+}
+
+type optionInspectManager struct {
+	name string
+	opts *manager.Options
+}
+
+func (m *optionInspectManager) Name() string { return m.name }
+
+func (m *optionInspectManager) IsAvailable() bool { return true }
+
+func (m *optionInspectManager) CheckOutdated(context.Context) ([]manager.Package, error) {
+	return nil, nil
+}
+
+func (m *optionInspectManager) Upgrade(context.Context, bool) (*manager.UpgradeResult, error) {
+	return &manager.UpgradeResult{}, nil
+}
+
+func (m *optionInspectManager) Cleanup(context.Context) error { return nil }
+
+func (m *optionInspectManager) SetSkipList(packages []string) { m.opts.SkipList = packages }

--- a/go/sarasa/internal/manager/registry.go
+++ b/go/sarasa/internal/manager/registry.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -27,7 +28,7 @@ func Get(name string, opts *Options) (Manager, error) {
 		return nil, fmt.Errorf("unknown manager: %s", name)
 	}
 
-	return factory(opts), nil
+	return factory(opts.Clone()), nil
 }
 
 // List returns all registered manager names.
@@ -39,6 +40,7 @@ func List() []string {
 	for name := range registry {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return names
 }
 
@@ -49,7 +51,7 @@ func Available(opts *Options) []Manager {
 
 	var managers []Manager
 	for _, factory := range registry {
-		m := factory(opts)
+		m := factory(opts.Clone())
 		if m.IsAvailable() {
 			managers = append(managers, m)
 		}

--- a/go/sarasa/internal/runengine/runner.go
+++ b/go/sarasa/internal/runengine/runner.go
@@ -1,0 +1,156 @@
+package runengine
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/indrasvat/sarasa/internal/logger"
+	"github.com/indrasvat/sarasa/internal/manager"
+)
+
+// ConfigProvider provides per-manager configuration.
+type ConfigProvider interface {
+	GetSkipList(manager string) []string
+}
+
+// ManagerResult contains one manager's run outcome.
+type ManagerResult struct {
+	Name         string
+	Available    bool
+	Duration     time.Duration
+	Upgraded     []manager.Package
+	Failed       []manager.Package
+	Skipped      []manager.Package
+	Error        error
+	CleanupError error
+}
+
+// Summary contains aggregate run counts.
+type Summary struct {
+	Upgraded      int
+	Failed        int
+	Skipped       int
+	WouldUpgrade  int
+	ManagerErrors int
+}
+
+// Output is the complete result of a run.
+type Output struct {
+	DryRun   bool
+	Success  bool
+	Duration time.Duration
+	Summary  Summary
+	Managers []ManagerResult
+}
+
+// Runner executes manager upgrades.
+type Runner struct {
+	DryRun         bool
+	SkipCleanup    bool
+	MaxParallel    int
+	ConfigProvider ConfigProvider
+}
+
+// Run executes managers concurrently and returns results in input order.
+func (r Runner) Run(ctx context.Context, managers []manager.Manager) Output {
+	start := time.Now()
+	output := Output{
+		DryRun:   r.DryRun,
+		Success:  true,
+		Managers: make([]ManagerResult, len(managers)),
+	}
+	if len(managers) == 0 {
+		output.Duration = time.Since(start)
+		return output
+	}
+
+	parallelism := r.MaxParallel
+	if parallelism <= 0 || parallelism > len(managers) {
+		parallelism = len(managers)
+	}
+
+	sem := make(chan struct{}, parallelism)
+	var wg sync.WaitGroup
+	for i, mgr := range managers {
+		i, mgr := i, mgr
+		output.Managers[i] = ManagerResult{Name: mgr.Name(), Available: true}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				result := ManagerResult{Name: mgr.Name(), Available: true, Error: ctx.Err()}
+				output.Managers[i] = result
+				return
+			}
+
+			result := r.runOne(ctx, mgr)
+			output.Managers[i] = result
+		}()
+	}
+	wg.Wait()
+	if !r.DryRun && !r.SkipCleanup && ctx.Err() == nil {
+		for i, mgr := range managers {
+			if output.Managers[i].Error != nil {
+				continue
+			}
+			if err := mgr.Cleanup(ctx); err != nil {
+				output.Managers[i].CleanupError = err
+			}
+		}
+	}
+
+	output.Duration = time.Since(start)
+	output.Summary = reduce(output.Managers, r.DryRun)
+	output.Success = output.Summary.Failed == 0 && output.Summary.ManagerErrors == 0
+	return output
+}
+
+func (r Runner) runOne(ctx context.Context, mgr manager.Manager) ManagerResult {
+	result := ManagerResult{Name: mgr.Name(), Available: true}
+	if r.ConfigProvider != nil {
+		mgr.SetSkipList(r.ConfigProvider.GetSkipList(mgr.Name()))
+	}
+	logger.LogStart(mgr.Name())
+	start := time.Now()
+	upgradeResult, err := mgr.Upgrade(ctx, r.DryRun)
+	result.Duration = time.Since(start)
+	if err != nil {
+		result.Error = err
+		logger.LogComplete(mgr.Name(), 0, 1, result.Duration.Milliseconds())
+		return result
+	}
+	if upgradeResult == nil {
+		upgradeResult = &manager.UpgradeResult{}
+	}
+
+	result.Upgraded = upgradeResult.Upgraded
+	result.Failed = upgradeResult.Failed
+	result.Skipped = upgradeResult.Skipped
+
+	logger.LogComplete(mgr.Name(), len(result.Upgraded), len(result.Failed), result.Duration.Milliseconds())
+	return result
+}
+
+func reduce(results []ManagerResult, dryRun bool) Summary {
+	var summary Summary
+	for _, result := range results {
+		if result.Error != nil {
+			summary.ManagerErrors++
+		}
+		if dryRun {
+			summary.WouldUpgrade += len(result.Skipped)
+		} else {
+			summary.Skipped += len(result.Skipped)
+		}
+		summary.Upgraded += len(result.Upgraded)
+		summary.Failed += len(result.Failed)
+		if result.CleanupError != nil {
+			summary.ManagerErrors++
+		}
+	}
+	return summary
+}

--- a/go/sarasa/internal/runengine/runner_bench_test.go
+++ b/go/sarasa/internal/runengine/runner_bench_test.go
@@ -1,0 +1,39 @@
+package runengine
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/indrasvat/sarasa/internal/logger"
+	"github.com/indrasvat/sarasa/internal/manager"
+)
+
+func BenchmarkRunnerFakeManagers(b *testing.B) {
+	if err := logger.Init(logger.Config{Dir: b.TempDir()}); err != nil {
+		b.Fatalf("init logger: %v", err)
+	}
+	b.Cleanup(func() { _ = logger.Close() })
+
+	for _, count := range []int{1, 4, 8} {
+		b.Run(fmt.Sprintf("managers_%d", count), func(b *testing.B) {
+			managers := make([]manager.Manager, 0, count)
+			for i := 0; i < count; i++ {
+				managers = append(managers, &fakeManager{
+					name: fmt.Sprintf("manager-%d", i),
+					result: &manager.UpgradeResult{
+						Upgraded: []manager.Package{{Name: "pkg"}},
+					},
+				})
+			}
+			runner := Runner{SkipCleanup: true}
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				output := runner.Run(context.Background(), managers)
+				if !output.Success {
+					b.Fatalf("runner failed: %+v", output)
+				}
+			}
+		})
+	}
+}

--- a/go/sarasa/internal/runengine/runner_test.go
+++ b/go/sarasa/internal/runengine/runner_test.go
@@ -1,0 +1,151 @@
+package runengine
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/indrasvat/sarasa/internal/manager"
+)
+
+func TestRunnerRunsManagersConcurrentlyAndReturnsInputOrder(t *testing.T) {
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+
+	slow := &fakeManager{
+		name: "slow",
+		upgrade: func(context.Context, bool) (*manager.UpgradeResult, error) {
+			close(firstStarted)
+			<-releaseFirst
+			return &manager.UpgradeResult{
+				Upgraded: []manager.Package{{Name: "slow-pkg"}},
+			}, nil
+		},
+	}
+	fast := &fakeManager{
+		name: "fast",
+		upgrade: func(context.Context, bool) (*manager.UpgradeResult, error) {
+			select {
+			case <-firstStarted:
+			case <-time.After(time.Second):
+				t.Fatal("fast manager did not start after slow manager")
+			}
+			close(releaseFirst)
+			return &manager.UpgradeResult{
+				Upgraded: []manager.Package{{Name: "fast-pkg"}},
+			}, nil
+		},
+	}
+
+	output := Runner{}.Run(context.Background(), []manager.Manager{slow, fast})
+
+	if len(output.Managers) != 2 {
+		t.Fatalf("got %d manager results, want 2", len(output.Managers))
+	}
+	if output.Managers[0].Name != "slow" || output.Managers[1].Name != "fast" {
+		t.Fatalf("manager order = [%s %s], want [slow fast]", output.Managers[0].Name, output.Managers[1].Name)
+	}
+	if output.Summary.Upgraded != 2 {
+		t.Fatalf("Summary.Upgraded = %d, want 2", output.Summary.Upgraded)
+	}
+}
+
+func TestRunnerIsolatesManagerErrors(t *testing.T) {
+	output := Runner{}.Run(context.Background(), []manager.Manager{
+		&fakeManager{name: "bad", err: errors.New("boom")},
+		&fakeManager{name: "good", result: &manager.UpgradeResult{
+			Upgraded: []manager.Package{{Name: "ok"}},
+		}},
+	})
+
+	if output.Success {
+		t.Fatal("output.Success = true, want false")
+	}
+	if output.Summary.ManagerErrors != 1 {
+		t.Fatalf("ManagerErrors = %d, want 1", output.Summary.ManagerErrors)
+	}
+	if output.Summary.Upgraded != 1 {
+		t.Fatalf("Upgraded = %d, want 1", output.Summary.Upgraded)
+	}
+}
+
+func TestRunnerRunsCleanupAfterAllUpgradesFinish(t *testing.T) {
+	firstUpgradeStarted := make(chan struct{})
+	releaseFirstUpgrade := make(chan struct{})
+	firstUpgradeDone := make(chan struct{})
+
+	first := &fakeManager{
+		name: "first",
+		upgrade: func(context.Context, bool) (*manager.UpgradeResult, error) {
+			close(firstUpgradeStarted)
+			<-releaseFirstUpgrade
+			close(firstUpgradeDone)
+			return &manager.UpgradeResult{}, nil
+		},
+	}
+	secondCleanupChecked := make(chan struct{})
+	second := &fakeManager{
+		name: "second",
+		upgrade: func(context.Context, bool) (*manager.UpgradeResult, error) {
+			<-firstUpgradeStarted
+			return &manager.UpgradeResult{}, nil
+		},
+		cleanup: func(context.Context) error {
+			select {
+			case <-firstUpgradeDone:
+			default:
+				t.Fatal("cleanup started before all upgrades finished")
+			}
+			close(secondCleanupChecked)
+			return nil
+		},
+	}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(releaseFirstUpgrade)
+	}()
+	output := Runner{}.Run(context.Background(), []manager.Manager{first, second})
+	if !output.Success {
+		t.Fatalf("output.Success = false, want true: %+v", output)
+	}
+	select {
+	case <-secondCleanupChecked:
+	case <-time.After(time.Second):
+		t.Fatal("second cleanup did not run")
+	}
+}
+
+type fakeManager struct {
+	name    string
+	result  *manager.UpgradeResult
+	err     error
+	upgrade func(context.Context, bool) (*manager.UpgradeResult, error)
+	cleanup func(context.Context) error
+}
+
+func (f *fakeManager) Name() string { return f.name }
+
+func (f *fakeManager) IsAvailable() bool { return true }
+
+func (f *fakeManager) CheckOutdated(context.Context) ([]manager.Package, error) { return nil, nil }
+
+func (f *fakeManager) Upgrade(ctx context.Context, dryRun bool) (*manager.UpgradeResult, error) {
+	if f.upgrade != nil {
+		return f.upgrade(ctx, dryRun)
+	}
+	if f.result != nil || f.err != nil {
+		return f.result, f.err
+	}
+	return &manager.UpgradeResult{}, nil
+}
+
+func (f *fakeManager) Cleanup(ctx context.Context) error {
+	if f.cleanup != nil {
+		return f.cleanup(ctx)
+	}
+	return nil
+}
+
+func (f *fakeManager) SetSkipList([]string) {}

--- a/go/sarasa/internal/runlock/runlock.go
+++ b/go/sarasa/internal/runlock/runlock.go
@@ -1,0 +1,58 @@
+package runlock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+var ErrAlreadyRunning = errors.New("another sarasa run is already in progress")
+
+// Lock is an acquired process-level Sarasa run lock.
+type Lock struct {
+	file *os.File
+}
+
+// Acquire obtains the default non-blocking run lock.
+func Acquire() (*Lock, error) {
+	return AcquireAt(defaultPath())
+}
+
+// AcquireAt obtains a non-blocking run lock at path.
+func AcquireAt(path string) (*Lock, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create lock directory: %w", err)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open run lock: %w", err)
+	}
+	if err := lockFile(file); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return &Lock{file: file}, nil
+}
+
+// Close releases the run lock.
+func (l *Lock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	err := unlockFile(l.file)
+	closeErr := l.file.Close()
+	l.file = nil
+	if err != nil {
+		return err
+	}
+	return closeErr
+}
+
+func defaultPath() string {
+	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
+		return filepath.Join(xdg, "sarasa", "run.lock")
+	}
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, "Library", "Caches", "sarasa", "run.lock")
+}

--- a/go/sarasa/internal/runlock/runlock_test.go
+++ b/go/sarasa/internal/runlock/runlock_test.go
@@ -1,0 +1,42 @@
+package runlock
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestAcquireAtFailsFastWhenAlreadyLocked(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.lock")
+	first, err := AcquireAt(path)
+	if err != nil {
+		t.Fatalf("first AcquireAt failed: %v", err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+
+	second, err := AcquireAt(path)
+	if err == nil {
+		_ = second.Close()
+		t.Fatal("second AcquireAt succeeded, want ErrAlreadyRunning")
+	}
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("second AcquireAt error = %v, want ErrAlreadyRunning", err)
+	}
+}
+
+func TestAcquireAtReleasesOnClose(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "run.lock")
+	first, err := AcquireAt(path)
+	if err != nil {
+		t.Fatalf("first AcquireAt failed: %v", err)
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	second, err := AcquireAt(path)
+	if err != nil {
+		t.Fatalf("second AcquireAt failed after close: %v", err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+}

--- a/go/sarasa/internal/runlock/runlock_unix.go
+++ b/go/sarasa/internal/runlock/runlock_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package runlock
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func lockFile(file *os.File) error {
+	err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, syscall.EWOULDBLOCK) {
+		return ErrAlreadyRunning
+	}
+	return err
+}
+
+func unlockFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/go/sarasa/internal/runlock/runlock_windows.go
+++ b/go/sarasa/internal/runlock/runlock_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package runlock
+
+import "os"
+
+func lockFile(*os.File) error {
+	return nil
+}
+
+func unlockFile(*os.File) error {
+	return nil
+}

--- a/go/sarasa/internal/scheduler/launchd.go
+++ b/go/sarasa/internal/scheduler/launchd.go
@@ -34,6 +34,12 @@ const (
         <string>run</string>
     </array>
 
+    <key>Nice</key>
+    <integer>5</integer>
+
+    <key>LowPriorityIO</key>
+    <true/>
+
     <key>StartCalendarInterval</key>
     <array>
 {{- range .Times}}

--- a/go/sarasa/internal/scheduler/launchd_test.go
+++ b/go/sarasa/internal/scheduler/launchd_test.go
@@ -53,6 +53,8 @@ func TestGeneratePlistRendersConfiguredEnvironmentPath(t *testing.T) {
 		"<integer>9</integer>",
 		"<integer>30</integer>",
 		"<string>/tmp/bin:/usr/bin:/bin</string>",
+		"<key>LowPriorityIO</key>",
+		"<true/>",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("plist missing %q:\n%s", want, text)

--- a/go/sarasa/internal/shuxtest/fakemanager/fake.go
+++ b/go/sarasa/internal/shuxtest/fakemanager/fake.go
@@ -1,0 +1,157 @@
+package fakemanager
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/indrasvat/sarasa/internal/manager"
+)
+
+var (
+	barrier = newStartBarrier()
+	eventMu sync.Mutex
+)
+
+// RegisterBuiltins replaces real package managers with deterministic fakes.
+func RegisterBuiltins() {
+	expected := 3
+	if raw := os.Getenv("SARASA_SHUX_EXPECTED_MANAGERS"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			expected = parsed
+		}
+	}
+	barrier.expected = expected
+
+	manager.Register(manager.ManagerBrew, func(opts *manager.Options) manager.Manager {
+		return &fake{name: manager.ManagerBrew, opts: opts}
+	})
+	manager.Register(manager.ManagerVolta, func(opts *manager.Options) manager.Manager {
+		return &fake{name: manager.ManagerVolta, opts: opts}
+	})
+	manager.Register(manager.ManagerPipx, func(opts *manager.Options) manager.Manager {
+		return &fake{name: manager.ManagerPipx, opts: opts}
+	})
+}
+
+type fake struct {
+	name string
+	opts *manager.Options
+}
+
+func (f *fake) Name() string { return f.name }
+
+func (f *fake) IsAvailable() bool { return true }
+
+func (f *fake) CheckOutdated(context.Context) ([]manager.Package, error) { return nil, nil }
+
+func (f *fake) Upgrade(ctx context.Context, dryRun bool) (*manager.UpgradeResult, error) {
+	if err := barrier.start(ctx, f.name); err != nil {
+		return nil, err
+	}
+	defer barrier.done(f.name)
+
+	switch f.name {
+	case manager.ManagerBrew:
+		return &manager.UpgradeResult{
+			Upgraded: []manager.Package{{
+				Name:    "brew-upgraded",
+				Current: "1.0.0",
+				Latest:  "1.1.0",
+				Method:  "formula",
+			}},
+			Skipped: []manager.Package{{
+				Name:       "skip-me",
+				Current:    "2.0.0",
+				Latest:     "2.1.0",
+				Method:     "cask",
+				SkipReason: "in skip list",
+			}},
+		}, nil
+	case manager.ManagerVolta:
+		return &manager.UpgradeResult{
+			Failed: []manager.Package{{
+				Name:    "volta-failed",
+				Current: "3.0.0",
+				Latest:  "3.1.0",
+			}},
+		}, nil
+	default:
+		return &manager.UpgradeResult{}, nil
+	}
+}
+
+func (f *fake) Cleanup(context.Context) error { return nil }
+
+func (f *fake) SetSkipList(packages []string) {
+	if f.opts == nil {
+		f.opts = &manager.Options{}
+	}
+	f.opts.SkipList = append([]string(nil), packages...)
+}
+
+type startBarrier struct {
+	mu       sync.Mutex
+	expected int
+	started  int
+	ready    chan struct{}
+}
+
+func newStartBarrier() *startBarrier {
+	return &startBarrier{expected: 3, ready: make(chan struct{})}
+}
+
+func (b *startBarrier) start(ctx context.Context, name string) error {
+	b.mu.Lock()
+	b.started++
+	_ = writeEvent(name, "start")
+	if b.started >= b.expected {
+		select {
+		case <-b.ready:
+		default:
+			close(b.ready)
+		}
+	}
+	ready := b.ready
+	b.mu.Unlock()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(10 * time.Second):
+		return context.DeadlineExceeded
+	case <-ready:
+		return nil
+	}
+}
+
+func (b *startBarrier) done(name string) {
+	_ = writeEvent(name, "done")
+}
+
+func writeEvent(name, event string) error {
+	path := os.Getenv("SARASA_SHUX_EVENTS")
+	if path == "" {
+		return nil
+	}
+	eventMu.Lock()
+	defer eventMu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	if err := json.NewEncoder(file).Encode(map[string]string{
+		"manager": name,
+		"event":   event,
+	}); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}

--- a/go/sarasa/internal/shuxtest/sarasa-fake/main.go
+++ b/go/sarasa/internal/shuxtest/sarasa-fake/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/indrasvat/sarasa/cmd"
+	"github.com/indrasvat/sarasa/internal/shuxtest/fakemanager"
+)
+
+func main() {
+	fakemanager.RegisterBuiltins()
+	cmd.Execute()
+}

--- a/go/sarasa/internal/tui/run/model.go
+++ b/go/sarasa/internal/tui/run/model.go
@@ -26,12 +26,13 @@ type PackageStatus struct {
 
 // ManagerResult holds the upgrade results for a manager.
 type ManagerResult struct {
-	Name      string
-	Packages  []*PackageStatus
-	Status    string // "pending", "checking", "upgrading", "done", "error"
-	Error     error
-	Duration  time.Duration
-	StartTime time.Time
+	Name         string
+	Packages     []*PackageStatus
+	Status       string // "pending", "checking", "upgrading", "done", "error"
+	Error        error
+	CleanupError error
+	Duration     time.Duration
+	StartTime    time.Time
 }
 
 // Model is the bubbletea model for the run command.
@@ -47,6 +48,7 @@ type Model struct {
 	skipCleanup bool
 	running     bool
 	done        bool
+	cleaningUp  bool
 	startTime   time.Time
 	width       int
 	height      int
@@ -55,6 +57,9 @@ type Model struct {
 	totalUpgraded int
 	totalFailed   int
 	totalSkipped  int
+
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // ManagerConfigProvider provides per-manager config.
@@ -72,6 +77,9 @@ type (
 		result   *manager.UpgradeResult
 		duration time.Duration
 		err      error
+	}
+	cleanupDoneMsg struct {
+		errors map[int]error
 	}
 )
 
@@ -100,6 +108,7 @@ func New(managers []manager.Manager, opts *manager.Options, cfg ManagerConfigPro
 		}
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	return Model{
 		managers:    managers,
 		opts:        opts,
@@ -109,6 +118,8 @@ func New(managers []manager.Manager, opts *manager.Options, cfg ManagerConfigPro
 		progress:    p,
 		dryRun:      dryRun,
 		skipCleanup: skipCleanup,
+		ctx:         ctx,
+		cancel:      cancel,
 	}
 }
 
@@ -131,24 +142,11 @@ func (m Model) Init() tea.Cmd {
 func (m Model) runManager(index int) tea.Cmd {
 	mgr := m.managers[index]
 	dryRun := m.dryRun
-	skipCleanup := m.skipCleanup
 
 	return func() tea.Msg {
-		ctx := context.Background()
-
 		start := time.Now()
-		result, err := mgr.Upgrade(ctx, dryRun)
+		result, err := mgr.Upgrade(m.ctx, dryRun)
 		duration := time.Since(start)
-
-		// Run cleanup if not dry run and not skipped
-		if err == nil && !dryRun && !skipCleanup {
-			if cleanupErr := mgr.Cleanup(ctx); cleanupErr != nil {
-				logger.WithManager(mgr.Name()).Warn("Cleanup failed",
-					"error", cleanupErr.Error(),
-					"action", "cleanup",
-				)
-			}
-		}
 
 		return managerDoneMsg{
 			index:    index,
@@ -159,12 +157,34 @@ func (m Model) runManager(index int) tea.Cmd {
 	}
 }
 
+func (m Model) cleanupManagers() tea.Cmd {
+	return func() tea.Msg {
+		cleanupErrors := make(map[int]error)
+		for i, mgr := range m.managers {
+			if m.results[i].Status == "error" {
+				continue
+			}
+			if err := mgr.Cleanup(m.ctx); err != nil {
+				logger.WithManager(mgr.Name()).Warn("Cleanup failed",
+					"error", err.Error(),
+					"action", "cleanup",
+				)
+				cleanupErrors[i] = err
+			}
+		}
+		return cleanupDoneMsg{errors: cleanupErrors}
+	}
+}
+
 // Update handles messages.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c", "esc":
+			if m.cancel != nil {
+				m.cancel()
+			}
 			return m, tea.Quit
 		}
 
@@ -206,6 +226,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			result.Error = msg.err
 			m.totalFailed++
 		} else {
+			if msg.result == nil {
+				msg.result = &manager.UpgradeResult{}
+			}
 			result.Status = "done"
 			// Convert result packages to status
 			for _, pkg := range msg.result.Upgraded {
@@ -233,10 +256,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Check if all managers are done
 		if m.activeCount == 0 {
+			if !m.dryRun && !m.skipCleanup && m.ctx.Err() == nil {
+				m.cleaningUp = true
+				return m, tea.Batch(m.spinner.Tick, m.cleanupManagers())
+			}
 			m.running = false
 			m.done = true
 		}
 
+		return m, nil
+
+	case cleanupDoneMsg:
+		m.cleaningUp = false
+		m.running = false
+		m.done = true
+		for index, err := range msg.errors {
+			m.results[index].CleanupError = err
+			m.totalFailed++
+		}
 		return m, nil
 	}
 
@@ -257,28 +294,28 @@ func (m Model) View() string {
 		headerText = ui.StyleHeader.Render("SARASA UPGRADE")
 	}
 
-	if m.running {
-		b.WriteString(fmt.Sprintf("  %s %s  %s Upgrading packages...\n", headerIcon, headerText, m.spinner.View()))
-	} else {
-		b.WriteString(fmt.Sprintf("  %s %s\n", headerIcon, headerText))
+	switch {
+	case m.cleaningUp:
+		fmt.Fprintf(&b, "  %s %s  %s Cleaning up...\n", headerIcon, headerText, m.spinner.View())
+	case m.running:
+		fmt.Fprintf(&b, "  %s %s  %s Upgrading packages...\n", headerIcon, headerText, m.spinner.View())
+	default:
+		fmt.Fprintf(&b, "  %s %s\n", headerIcon, headerText)
 	}
 	b.WriteString("\n")
 
 	// Progress bar (only during upgrade)
-	if m.running && !m.dryRun {
+	if m.running && !m.dryRun && !m.cleaningUp {
 		elapsed := time.Since(m.startTime)
 		completed := len(m.managers) - m.activeCount
 		progressPct := float64(completed) / float64(len(m.managers))
-		b.WriteString(fmt.Sprintf("  %s  %s\n\n", m.progress.ViewAs(progressPct), ui.StyleDuration.Render(formatDuration(elapsed))))
+		fmt.Fprintf(&b, "  %s  %s\n\n", m.progress.ViewAs(progressPct), ui.StyleDuration.Render(formatDuration(elapsed)))
 	}
 
 	// Manager panels
 	panelWidth := 45
-	if m.width >= 90 {
-		panelWidth = min(76, m.width-6)
-	}
-	if m.width > 0 && m.width < 60 {
-		panelWidth = m.width - 6
+	if m.width > 0 {
+		panelWidth = min(76, max(20, m.width-6))
 	}
 
 	for _, result := range m.results {
@@ -314,7 +351,7 @@ func (m Model) renderManagerPanel(result *ManagerResult, width int) string {
 		content.WriteString(ui.StyleMuted.Render("waiting..."))
 	case "upgrading":
 		elapsed := time.Since(result.StartTime)
-		content.WriteString(fmt.Sprintf("%s %s", m.spinner.View(), ui.StyleDuration.Render(formatDuration(elapsed))))
+		fmt.Fprintf(&content, "%s %s", m.spinner.View(), ui.StyleDuration.Render(formatDuration(elapsed)))
 	case "error":
 		content.WriteString(ui.StyleError.Render(ui.IconCross + " " + result.Error.Error()))
 	case "done":
@@ -322,7 +359,7 @@ func (m Model) renderManagerPanel(result *ManagerResult, width int) string {
 			content.WriteString(ui.StyleSuccess.Render(ui.IconCheck + " Already up to date"))
 		} else {
 			durationStr := ui.StyleDuration.Render(fmt.Sprintf("(%s)", formatDuration(result.Duration)))
-			content.WriteString(fmt.Sprintf("%s\n", durationStr))
+			fmt.Fprintf(&content, "%s\n", durationStr)
 
 			// Package list
 			for i, pkg := range result.Packages {
@@ -360,11 +397,17 @@ func (m Model) renderManagerPanel(result *ManagerResult, width int) string {
 					reasonTag = " " + ui.StyleMethodTag.Render("· "+pkg.Package.SkipReason)
 				}
 
-				content.WriteString(fmt.Sprintf("  %s %s  %s %s %s%s%s%s", statusIcon, pkgName, current, arrow, latest, majorTag, methodTag, reasonTag))
+				fmt.Fprintf(&content, "  %s %s  %s %s %s%s%s%s", statusIcon, pkgName, current, arrow, latest, majorTag, methodTag, reasonTag)
 				if i < len(result.Packages)-1 {
 					content.WriteString("\n")
 				}
 			}
+		}
+		if result.CleanupError != nil {
+			if content.Len() > 0 {
+				content.WriteString("\n")
+			}
+			content.WriteString(ui.StyleWarning.Render(ui.IconWarning + " cleanup failed: " + result.CleanupError.Error()))
 		}
 	}
 
@@ -414,11 +457,11 @@ func (m Model) renderSummary() string {
 
 	separator := ui.StyleMuted.Render(" · ")
 	summaryLine := strings.Join(parts, separator)
-	b.WriteString(fmt.Sprintf("\n  %s  %s\n", summaryIcon, summaryLine))
+	fmt.Fprintf(&b, "\n  %s  %s\n", summaryIcon, summaryLine)
 
 	if m.dryRun && m.totalSkipped > 0 {
 		cmdStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.ColorPrimary)
-		b.WriteString(fmt.Sprintf("     Run %s to apply upgrades\n", cmdStyle.Render("sarasa run")))
+		fmt.Fprintf(&b, "     Run %s to apply upgrades\n", cmdStyle.Render("sarasa run"))
 	}
 
 	b.WriteString("\n")

--- a/go/sarasa/internal/tui/run/model_test.go
+++ b/go/sarasa/internal/tui/run/model_test.go
@@ -1,0 +1,160 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/indrasvat/sarasa/internal/manager"
+)
+
+func TestCleanupStartsOnlyAfterAllUpgradesFinish(t *testing.T) {
+	first := &cleanupSpyManager{name: "first"}
+	second := &cleanupSpyManager{name: "second"}
+
+	model := New([]manager.Manager{first, second}, &manager.Options{}, nil, false, false)
+	model = startManager(t, model, 0)
+	model = startManager(t, model, 1)
+
+	next, cmd := model.Update(managerDoneMsg{index: 0, result: &manager.UpgradeResult{}})
+	model = next.(Model)
+	if cmd != nil {
+		t.Fatal("cleanup started before all upgrades finished")
+	}
+	if first.cleanupCalls() != 0 || second.cleanupCalls() != 0 {
+		t.Fatalf("cleanup calls before all upgrades finished: first=%d second=%d", first.cleanupCalls(), second.cleanupCalls())
+	}
+
+	next, cmd = model.Update(managerDoneMsg{index: 1, result: &manager.UpgradeResult{}})
+	model = next.(Model)
+	if cmd == nil {
+		t.Fatal("cleanup command missing after final upgrade")
+	}
+	if !model.cleaningUp || model.done {
+		t.Fatalf("model state before cleanup = cleaningUp:%v done:%v, want cleaningUp:true done:false", model.cleaningUp, model.done)
+	}
+
+	msg := runCleanupCommand(t, cmd)
+	cleanupMsg, ok := msg.(cleanupDoneMsg)
+	if !ok {
+		t.Fatalf("cleanup command returned %T, want cleanupDoneMsg", msg)
+	}
+	if len(cleanupMsg.errors) != 0 {
+		t.Fatalf("cleanup errors = %+v, want none", cleanupMsg.errors)
+	}
+	if first.cleanupCalls() != 1 || second.cleanupCalls() != 1 {
+		t.Fatalf("cleanup calls = first:%d second:%d, want 1 each", first.cleanupCalls(), second.cleanupCalls())
+	}
+
+	model = updateModel(t, model, cleanupMsg)
+	if model.cleaningUp || model.running || !model.done {
+		t.Fatalf("model state after cleanup = cleaningUp:%v running:%v done:%v, want false false true", model.cleaningUp, model.running, model.done)
+	}
+}
+
+func TestCleanupSkipsManagersWithUpgradeErrors(t *testing.T) {
+	failed := &cleanupSpyManager{name: "failed"}
+	ok := &cleanupSpyManager{name: "ok"}
+
+	model := New([]manager.Manager{failed, ok}, &manager.Options{}, nil, false, false)
+	model = startManager(t, model, 0)
+	model = startManager(t, model, 1)
+	model = updateModel(t, model, managerDoneMsg{index: 0, err: errors.New("upgrade failed")})
+
+	next, cmd := model.Update(managerDoneMsg{index: 1, result: &manager.UpgradeResult{}})
+	model = next.(Model)
+	if cmd == nil {
+		t.Fatal("cleanup command missing after final upgrade")
+	}
+
+	msg := runCleanupCommand(t, cmd)
+	cleanupMsg, okMsg := msg.(cleanupDoneMsg)
+	if !okMsg {
+		t.Fatalf("cleanup command returned %T, want cleanupDoneMsg", msg)
+	}
+	if len(cleanupMsg.errors) != 0 {
+		t.Fatalf("cleanup errors = %+v, want none", cleanupMsg.errors)
+	}
+	if failed.cleanupCalls() != 0 || ok.cleanupCalls() != 1 {
+		t.Fatalf("cleanup calls = failed:%d ok:%d, want 0 and 1", failed.cleanupCalls(), ok.cleanupCalls())
+	}
+
+	model = updateModel(t, model, cleanupMsg)
+	if !model.done {
+		t.Fatal("model.done = false, want true")
+	}
+}
+
+func updateModel(t *testing.T, model Model, msg tea.Msg) Model {
+	t.Helper()
+	next, cmd := model.Update(msg)
+	if cmd != nil {
+		t.Fatalf("unexpected command for %T", msg)
+	}
+	return next.(Model)
+}
+
+func startManager(t *testing.T, model Model, index int) Model {
+	t.Helper()
+	next, cmd := model.Update(managerStartMsg{index: index})
+	if cmd == nil {
+		t.Fatalf("managerStartMsg[%d] did not return an upgrade command", index)
+	}
+	return next.(Model)
+}
+
+func runCleanupCommand(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		return msg
+	}
+	for _, batched := range batch {
+		if batched == nil {
+			continue
+		}
+		msg := batched()
+		if _, ok := msg.(cleanupDoneMsg); ok {
+			return msg
+		}
+	}
+	t.Fatal("cleanup command not found in batch")
+	return nil
+}
+
+type cleanupSpyManager struct {
+	name string
+	mu   sync.Mutex
+	n    int
+}
+
+func (m *cleanupSpyManager) Name() string { return m.name }
+
+func (m *cleanupSpyManager) IsAvailable() bool { return true }
+
+func (m *cleanupSpyManager) CheckOutdated(context.Context) ([]manager.Package, error) {
+	return nil, nil
+}
+
+func (m *cleanupSpyManager) Upgrade(context.Context, bool) (*manager.UpgradeResult, error) {
+	return &manager.UpgradeResult{}, nil
+}
+
+func (m *cleanupSpyManager) Cleanup(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.n++
+	return nil
+}
+
+func (m *cleanupSpyManager) SetSkipList([]string) {}
+
+func (m *cleanupSpyManager) cleanupCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.n
+}

--- a/go/sarasa/internal/tui/status/model.go
+++ b/go/sarasa/internal/tui/status/model.go
@@ -35,16 +35,18 @@ const (
 	stateLoading upgradeState = iota
 	stateViewing
 	stateUpgrading
+	stateCleaningUp
 	stateUpgraded
 )
 
 type upgradeResult struct {
-	Name     string
-	Packages []*packageResult
-	Status   string // "pending", "upgrading", "done", "error"
-	Error    error
-	Duration time.Duration
-	Start    time.Time
+	Name         string
+	Packages     []*packageResult
+	Status       string // "pending", "upgrading", "done", "error"
+	Error        error
+	CleanupError error
+	Duration     time.Duration
+	Start        time.Time
 }
 
 type packageResult struct {
@@ -82,6 +84,10 @@ type upgradeManagerDoneMsg struct {
 	result   *manager.UpgradeResult
 	duration time.Duration
 	err      error
+}
+
+type cleanupDoneMsg struct {
+	errors map[string]error
 }
 
 // New creates a new status TUI model.
@@ -182,15 +188,6 @@ func (m Model) runManagerUpgrade(name string) tea.Cmd {
 		result, err := mgr.Upgrade(ctx, false)
 		duration := time.Since(start)
 
-		if err == nil {
-			if cleanupErr := mgr.Cleanup(ctx); cleanupErr != nil {
-				logger.WithManager(name).Warn("Cleanup failed",
-					"error", cleanupErr.Error(),
-					"action", "cleanup",
-				)
-			}
-		}
-
 		return upgradeManagerDoneMsg{
 			name:     name,
 			result:   result,
@@ -200,7 +197,40 @@ func (m Model) runManagerUpgrade(name string) tea.Cmd {
 	}
 }
 
-// Update handles messages.
+func (m Model) cleanupUpgradedManagers() tea.Cmd {
+	opts := m.opts
+	cfgProvider := m.cfg
+	names := append([]string(nil), m.upgradeOrder...)
+
+	return func() tea.Msg {
+		ctx := context.Background()
+		cleanupErrors := make(map[string]error)
+		for _, name := range names {
+			result := m.upgradeResults[name]
+			if result == nil || result.Status == "error" {
+				continue
+			}
+			mgr, err := manager.Get(name, opts)
+			if err != nil {
+				cleanupErrors[name] = err
+				continue
+			}
+			if cfgProvider != nil {
+				mgr.SetSkipList(cfgProvider.GetSkipList(name))
+			}
+			if err := mgr.Cleanup(ctx); err != nil {
+				logger.WithManager(name).Warn("Cleanup failed",
+					"error", err.Error(),
+					"action", "cleanup",
+				)
+				cleanupErrors[name] = err
+			}
+		}
+		return cleanupDoneMsg{errors: cleanupErrors}
+	}
+}
+
+//nolint:gocyclo // Bubble Tea state-machine update path; splitting would obscure message flow.
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -293,6 +323,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			r.Status = "error"
 			r.Error = msg.err
 		} else {
+			if msg.result == nil {
+				msg.result = &manager.UpgradeResult{}
+			}
 			r.Status = "done"
 			for _, pkg := range msg.result.Upgraded {
 				r.Packages = append(r.Packages, &packageResult{
@@ -330,19 +363,37 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		logger.LogComplete(msg.name, upgraded, failed, msg.duration.Milliseconds())
 
 		if m.activeCount == 0 {
-			m.state = stateUpgraded
-			totalDuration := time.Since(m.startTime)
-			logger.Get().Info("Status upgrade completed",
-				"total_upgraded", m.totalUpgraded,
-				"total_failed", m.totalFailed,
-				"duration_ms", totalDuration.Milliseconds(),
-			)
+			if m.opts != nil && !m.opts.DryRun && !m.opts.SkipCleanup {
+				m.state = stateCleaningUp
+				return m, tea.Batch(m.spinner.Tick, m.cleanupUpgradedManagers())
+			}
+			m.finishUpgrade()
 		}
 
+		return m, nil
+
+	case cleanupDoneMsg:
+		for name, err := range msg.errors {
+			if result := m.upgradeResults[name]; result != nil {
+				result.CleanupError = err
+			}
+			m.totalFailed++
+		}
+		m.finishUpgrade()
 		return m, nil
 	}
 
 	return m, nil
+}
+
+func (m *Model) finishUpgrade() {
+	m.state = stateUpgraded
+	totalDuration := time.Since(m.startTime)
+	logger.Get().Info("Status upgrade completed",
+		"total_upgraded", m.totalUpgraded,
+		"total_failed", m.totalFailed,
+		"duration_ms", totalDuration.Milliseconds(),
+	)
 }
 
 // View renders the UI.
@@ -355,11 +406,13 @@ func (m Model) View() string {
 	headerText := ui.StyleHeader.Render("SARASA STATUS")
 	switch m.state {
 	case stateLoading:
-		b.WriteString(fmt.Sprintf("  %s %s %s\n", headerIcon, headerText, m.spinner.View()))
+		fmt.Fprintf(&b, "  %s %s %s\n", headerIcon, headerText, m.spinner.View())
 	case stateUpgrading:
-		b.WriteString(fmt.Sprintf("  %s %s  %s Upgrading...\n", headerIcon, headerText, m.spinner.View()))
+		fmt.Fprintf(&b, "  %s %s  %s Upgrading...\n", headerIcon, headerText, m.spinner.View())
+	case stateCleaningUp:
+		fmt.Fprintf(&b, "  %s %s  %s Cleaning up...\n", headerIcon, headerText, m.spinner.View())
 	case stateViewing, stateUpgraded:
-		b.WriteString(fmt.Sprintf("  %s %s\n", headerIcon, headerText))
+		fmt.Fprintf(&b, "  %s %s\n", headerIcon, headerText)
 	}
 	b.WriteString("\n")
 
@@ -381,7 +434,7 @@ func (m Model) View() string {
 		status := m.statuses[name]
 
 		// If upgrading/upgraded and this manager has an upgrade result, show upgrade panel
-		if (m.state == stateUpgrading || m.state == stateUpgraded) && m.upgradeResults != nil {
+		if (m.state == stateUpgrading || m.state == stateCleaningUp || m.state == stateUpgraded) && m.upgradeResults != nil {
 			if ur, ok := m.upgradeResults[name]; ok {
 				b.WriteString(m.renderUpgradePanel(name, ur, panelWidth))
 				// Don't count stats for upgrade panels
@@ -412,7 +465,7 @@ func (m Model) View() string {
 		b.WriteString(m.renderSummary(totalOutdated, totalUpToDate, totalUnavailable, totalErrors))
 	case stateUpgraded:
 		b.WriteString(m.renderUpgradeSummary())
-	case stateLoading, stateUpgrading:
+	case stateLoading, stateUpgrading, stateCleaningUp:
 		// No summary while loading or upgrading
 	}
 
@@ -428,6 +481,8 @@ func (m Model) View() string {
 			b.WriteString(helpStyle.Render("  r refresh  ·  q quit"))
 		}
 	case stateUpgrading:
+		b.WriteString(helpStyle.Render("  q quit"))
+	case stateCleaningUp:
 		b.WriteString(helpStyle.Render("  q quit"))
 	case stateUpgraded:
 		b.WriteString(helpStyle.Render("  r refresh  ·  q quit"))
@@ -451,7 +506,7 @@ func (m Model) renderManagerPanel(name string, status *ManagerStatus, width int)
 
 	switch {
 	case status.Loading:
-		content.WriteString(fmt.Sprintf("%s Loading...", m.spinner.View()))
+		fmt.Fprintf(&content, "%s Loading...", m.spinner.View())
 	case !status.Available:
 		content.WriteString(ui.StyleMuted.Render(ui.IconCross + " Not installed"))
 	case status.Error != nil:
@@ -460,7 +515,7 @@ func (m Model) renderManagerPanel(name string, status *ManagerStatus, width int)
 		content.WriteString(ui.StyleSuccess.Render(ui.IconCheck + " All up to date"))
 	default:
 		outdatedCount := ui.StyleWarning.Render(fmt.Sprintf("%d outdated", len(status.Outdated)))
-		content.WriteString(fmt.Sprintf("%s\n", outdatedCount))
+		fmt.Fprintf(&content, "%s\n", outdatedCount)
 
 		// Package list
 		for i, pkg := range status.Outdated {
@@ -480,7 +535,7 @@ func (m Model) renderManagerPanel(name string, status *ManagerStatus, width int)
 
 			mgrColor := ui.ManagerColor(name)
 			triangle := lipgloss.NewStyle().Foreground(mgrColor).Render(ui.IconTriangle)
-			content.WriteString(fmt.Sprintf("  %s %s  %s %s %s%s%s", triangle, pkgName, current, arrow, latest, majorTag, methodTag))
+			fmt.Fprintf(&content, "  %s %s  %s %s %s%s%s", triangle, pkgName, current, arrow, latest, majorTag, methodTag)
 			if i < len(status.Outdated)-1 {
 				content.WriteString("\n")
 			}
@@ -509,7 +564,7 @@ func (m Model) renderUpgradePanel(name string, result *upgradeResult, width int)
 		content.WriteString(ui.StyleMuted.Render("waiting..."))
 	case "upgrading":
 		elapsed := time.Since(result.Start)
-		content.WriteString(fmt.Sprintf("%s %s", m.spinner.View(), ui.StyleDuration.Render(formatDuration(elapsed))))
+		fmt.Fprintf(&content, "%s %s", m.spinner.View(), ui.StyleDuration.Render(formatDuration(elapsed)))
 	case "error":
 		content.WriteString(ui.StyleError.Render(ui.IconCross + " " + result.Error.Error()))
 	case "done":
@@ -517,7 +572,7 @@ func (m Model) renderUpgradePanel(name string, result *upgradeResult, width int)
 			content.WriteString(ui.StyleSuccess.Render(ui.IconCheck + " Already up to date"))
 		} else {
 			durationStr := ui.StyleDuration.Render(fmt.Sprintf("(%s)", formatDuration(result.Duration)))
-			content.WriteString(fmt.Sprintf("%s\n", durationStr))
+			fmt.Fprintf(&content, "%s\n", durationStr)
 
 			for i, pkg := range result.Packages {
 				var statusIcon string
@@ -554,12 +609,18 @@ func (m Model) renderUpgradePanel(name string, result *upgradeResult, width int)
 					reasonTag = " " + ui.StyleMethodTag.Render("· "+pkg.Package.SkipReason)
 				}
 
-				content.WriteString(fmt.Sprintf("  %s %s  %s %s %s%s%s%s", statusIcon, pkgName, current, arrow, latest, majorTag, methodTag, reasonTag))
+				fmt.Fprintf(&content, "  %s %s  %s %s %s%s%s%s", statusIcon, pkgName, current, arrow, latest, majorTag, methodTag, reasonTag)
 				if i < len(result.Packages)-1 {
 					content.WriteString("\n")
 				}
 			}
 		}
+	}
+	if result.CleanupError != nil {
+		if content.Len() > 0 {
+			content.WriteString("\n")
+		}
+		content.WriteString(ui.StyleWarning.Render(ui.IconWarning + " cleanup failed: " + result.CleanupError.Error()))
 	}
 
 	panelStyle := ui.GetManagerPanelStyle(name).Width(width).MarginLeft(2)
@@ -587,12 +648,12 @@ func (m Model) renderSummary(outdated, upToDate, unavailable, errors int) string
 	if len(parts) > 0 {
 		separator := ui.StyleMuted.Render(" · ")
 		summaryLine := strings.Join(parts, separator)
-		b.WriteString(fmt.Sprintf("  %s  %s\n", ui.StyleSummaryIcon.Render(ui.IconSparkle), summaryLine))
+		fmt.Fprintf(&b, "  %s  %s\n", ui.StyleSummaryIcon.Render(ui.IconSparkle), summaryLine)
 	}
 
 	if outdated > 0 {
 		keyStyle := lipgloss.NewStyle().Bold(true).Foreground(ui.ColorPrimary)
-		b.WriteString(fmt.Sprintf("     Press %s to upgrade\n", keyStyle.Render("u")))
+		fmt.Fprintf(&b, "     Press %s to upgrade\n", keyStyle.Render("u"))
 	}
 
 	b.WriteString("\n")
@@ -627,7 +688,7 @@ func (m Model) renderUpgradeSummary() string {
 
 	separator := ui.StyleMuted.Render(" · ")
 	summaryLine := strings.Join(parts, separator)
-	b.WriteString(fmt.Sprintf("\n  %s  %s\n", summaryIcon, summaryLine))
+	fmt.Fprintf(&b, "\n  %s  %s\n", summaryIcon, summaryLine)
 	b.WriteString("\n")
 	return b.String()
 }

--- a/go/sarasa/internal/tui/status/model_test.go
+++ b/go/sarasa/internal/tui/status/model_test.go
@@ -1,0 +1,166 @@
+package status
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/indrasvat/sarasa/internal/manager"
+)
+
+func TestStatusCleanupStartsOnlyAfterAllUpgradesFinish(t *testing.T) {
+	first := "test-status-cleanup-first"
+	second := "test-status-cleanup-second"
+	firstSpy := registerCleanupSpy(t, first)
+	secondSpy := registerCleanupSpy(t, second)
+
+	model := newUpgradeModel(first, second)
+	model = updateStatusModel(t, model, upgradeManagerDoneMsg{name: first, result: &manager.UpgradeResult{}})
+	if firstSpy.cleanupCalls() != 0 || secondSpy.cleanupCalls() != 0 {
+		t.Fatalf("cleanup calls before all upgrades finished: first=%d second=%d", firstSpy.cleanupCalls(), secondSpy.cleanupCalls())
+	}
+
+	next, cmd := model.Update(upgradeManagerDoneMsg{name: second, result: &manager.UpgradeResult{}})
+	model = next.(Model)
+	if cmd == nil {
+		t.Fatal("cleanup command missing after final upgrade")
+	}
+	if model.state != stateCleaningUp {
+		t.Fatalf("state = %v, want stateCleaningUp", model.state)
+	}
+
+	msg := runStatusCleanupCommand(t, cmd)
+	cleanupMsg, ok := msg.(cleanupDoneMsg)
+	if !ok {
+		t.Fatalf("cleanup command returned %T, want cleanupDoneMsg", msg)
+	}
+	if len(cleanupMsg.errors) != 0 {
+		t.Fatalf("cleanup errors = %+v, want none", cleanupMsg.errors)
+	}
+	if firstSpy.cleanupCalls() != 1 || secondSpy.cleanupCalls() != 1 {
+		t.Fatalf("cleanup calls = first:%d second:%d, want 1 each", firstSpy.cleanupCalls(), secondSpy.cleanupCalls())
+	}
+
+	model = updateStatusModel(t, model, cleanupMsg)
+	if model.state != stateUpgraded {
+		t.Fatalf("state = %v, want stateUpgraded", model.state)
+	}
+}
+
+func TestStatusCleanupSkipsManagersWithUpgradeErrors(t *testing.T) {
+	failed := "test-status-cleanup-failed"
+	ok := "test-status-cleanup-ok"
+	failedSpy := registerCleanupSpy(t, failed)
+	okSpy := registerCleanupSpy(t, ok)
+
+	model := newUpgradeModel(failed, ok)
+	model = updateStatusModel(t, model, upgradeManagerDoneMsg{name: failed, err: errors.New("upgrade failed")})
+
+	next, cmd := model.Update(upgradeManagerDoneMsg{name: ok, result: &manager.UpgradeResult{}})
+	model = next.(Model)
+	if cmd == nil {
+		t.Fatal("cleanup command missing after final upgrade")
+	}
+	msg := runStatusCleanupCommand(t, cmd)
+	cleanupMsg, okMsg := msg.(cleanupDoneMsg)
+	if !okMsg {
+		t.Fatalf("cleanup command returned %T, want cleanupDoneMsg", msg)
+	}
+	if len(cleanupMsg.errors) != 0 {
+		t.Fatalf("cleanup errors = %+v, want none", cleanupMsg.errors)
+	}
+	if failedSpy.cleanupCalls() != 0 || okSpy.cleanupCalls() != 1 {
+		t.Fatalf("cleanup calls = failed:%d ok:%d, want 0 and 1", failedSpy.cleanupCalls(), okSpy.cleanupCalls())
+	}
+
+	model = updateStatusModel(t, model, cleanupMsg)
+	if model.state != stateUpgraded {
+		t.Fatalf("state = %v, want stateUpgraded", model.state)
+	}
+}
+
+func newUpgradeModel(names ...string) Model {
+	model := New(names, &manager.Options{}, nil)
+	model.state = stateUpgrading
+	model.startTime = time.Now()
+	model.upgradeResults = make(map[string]*upgradeResult, len(names))
+	model.upgradeOrder = append([]string(nil), names...)
+	model.activeCount = len(names)
+	for _, name := range names {
+		model.upgradeResults[name] = &upgradeResult{Name: name, Status: "upgrading"}
+	}
+	return model
+}
+
+func updateStatusModel(t *testing.T, model Model, msg tea.Msg) Model {
+	t.Helper()
+	next, cmd := model.Update(msg)
+	if cmd != nil {
+		t.Fatalf("unexpected command for %T", msg)
+	}
+	return next.(Model)
+}
+
+func registerCleanupSpy(t *testing.T, name string) *statusCleanupSpy {
+	t.Helper()
+	spy := &statusCleanupSpy{name: name}
+	manager.Register(name, func(*manager.Options) manager.Manager { return spy })
+	return spy
+}
+
+func runStatusCleanupCommand(t *testing.T, cmd tea.Cmd) tea.Msg {
+	t.Helper()
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		return msg
+	}
+	for _, batched := range batch {
+		if batched == nil {
+			continue
+		}
+		msg := batched()
+		if _, ok := msg.(cleanupDoneMsg); ok {
+			return msg
+		}
+	}
+	t.Fatal("cleanup command not found in batch")
+	return nil
+}
+
+type statusCleanupSpy struct {
+	name string
+	mu   sync.Mutex
+	n    int
+}
+
+func (m *statusCleanupSpy) Name() string { return m.name }
+
+func (m *statusCleanupSpy) IsAvailable() bool { return true }
+
+func (m *statusCleanupSpy) CheckOutdated(context.Context) ([]manager.Package, error) {
+	return nil, nil
+}
+
+func (m *statusCleanupSpy) Upgrade(context.Context, bool) (*manager.UpgradeResult, error) {
+	return &manager.UpgradeResult{}, nil
+}
+
+func (m *statusCleanupSpy) Cleanup(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.n++
+	return nil
+}
+
+func (m *statusCleanupSpy) SetSkipList([]string) {}
+
+func (m *statusCleanupSpy) cleanupCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.n
+}


### PR DESCRIPTION
## Summary

Sarasa scheduled runs now execute package managers in parallel instead of serializing the plain/JSON launchd path. The run flow uses an ordered concurrent runner for non-interactive output, keeps TUI behavior parallel, and preserves configured manager ordering in plain/JSON results so logs remain readable and deterministic.

The fix also hardens the non-interactive contract: each manager gets cloned options so skip-list mutation cannot bleed across goroutines, overlapping launchd/manual invocations fail fast through a process lock, cleanup runs only after every upgrade phase completes, and Brew commands use scoped timeouts plus process-group cancellation for stuck subprocesses.

## Proofs

- `cmd` JSON/plain tests prove managers overlap while output stays in requested order.
- `internal/runengine` tests prove concurrent execution, error isolation, and cleanup-after-all-upgrades behavior.
- `internal/tui/run` and `internal/tui/status` tests prove TUI cleanup is also delayed until all upgrades finish.
- `runlock` tests prove overlapping runs fail fast and release correctly.
- shux validation runs the real TUI at `80x24` and `120x40`, verifying all fake managers start before any completes.
- shux real-Brew validation runs the built Sarasa binary through the real Brew manager path against a fake `brew`, proving a controlled `1.0.0 -> 1.1.0` upgrade.

## Validation

- `make lint`
- `make test`
- `go test -race ./internal/exec ./internal/runlock ./internal/runengine ./internal/manager ./internal/tui/run ./internal/tui/status ./cmd -count=10`
- `.shux/scripts/validate-run-tui.sh`
- `.shux/scripts/validate-run-tui-real-brew.sh`
- `go test -bench=. -benchmem -run '^$' ./internal/runengine -count=5`
- `make build && ./sarasa version`